### PR TITLE
Call the next middleware for execution after response is set

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -118,8 +118,8 @@ module.exports = function(app, route, modelName, model) {
           default:
             res.status(res.resource.status).json(res.resource.item);
             break;
-          return next();
         }
+        return next();
       }
     },
 

--- a/Resource.js
+++ b/Resource.js
@@ -79,40 +79,46 @@ module.exports = function(app, route, modelName, model) {
     },
 
     /**
-     * The different responses.
+     * Sets the different responses and calls the next middleware for
+     * execution.
+     *
      * @param res
      *   The response to send to the client.
-     *
-     * @returns Response or NULL.
+     * @param next
+     *   The next middleware
      */
     respond: function(req, res, next) {
       if (req.noResponse) { return next(); }
       if (res.resource) {
         switch (res.resource.status) {
           case 400:
-            return res.status(400).json({
+            res.status(400).json({
               status: 400,
               message: res.resource.error.message,
               errors: _.mapValues(res.resource.error.errors, function(error) {
                 return _.pick(error, 'path', 'name', 'message');
               })
             });
+            break;
           case 404:
-            return res.status(404).json({
+            res.status(404).json({
               status: 404,
               errors: ['Resource not found']
             });
+            break;
           case 500:
-            return res.status(500).json({
+            res.status(500).json({
               status: 500,
               message: res.resource.error.message,
               errors: _.mapValues(res.resource.error.errors, function(error) {
                 return _.pick(error, 'path', 'name', 'message');
               })
             });
+            break;
           default:
             res.status(res.resource.status).json(res.resource.item);
-            return next();
+            break;
+          return next();
         }
       }
     },

--- a/Resource.js
+++ b/Resource.js
@@ -85,8 +85,8 @@ module.exports = function(app, route, modelName, model) {
      *
      * @returns Response or NULL.
      */
-    respond: function(req, res) {
-      if (req.noResponse) { return; }
+    respond: function(req, res, next) {
+      if (req.noResponse) { return next(); }
       if (res.resource) {
         switch (res.resource.status) {
           case 400:
@@ -111,7 +111,8 @@ module.exports = function(app, route, modelName, model) {
               })
             });
           default:
-            return res.status(res.resource.status).json(res.resource.item);
+            res.status(res.resource.status).json(res.resource.item);
+            return next();
         }
       }
     },

--- a/Resource.js
+++ b/Resource.js
@@ -54,10 +54,7 @@ module.exports = function(app, route, modelName, model) {
     register: function(app, method, path, callback, last, options) {
       var args = [path];
       if (options && options.before) {
-        before = [].concat options.before
-        for (var len = before.length, i=0; i<len; ++i) {
-          args.push(before[i].bind(this));
-        }
+        args.push(options.before.bind(this));
       }
       args.push(callback.bind(this));
       if (options && options.after) {

--- a/Resource.js
+++ b/Resource.js
@@ -54,7 +54,10 @@ module.exports = function(app, route, modelName, model) {
     register: function(app, method, path, callback, last, options) {
       var args = [path];
       if (options && options.before) {
-        args.push(options.before.bind(this));
+        before = [].concat options.before
+        for (var len = before.length, i=0; i<len; ++i) {
+          args.push(before[i].bind(this));
+        }
       }
       args.push(callback.bind(this));
       if (options && options.after) {


### PR DESCRIPTION
**Problem**
I need to execute middleware after resourcejs has finished processing (to emit a socket event). Currently execution stops after resourcejs has set its response.

**Solution**
The `respond` function signature has been updated to include the `next` function parameter. This is then called after the response has been set thus enabling the execution of any post-resourcejs middleware.