### PR TITLE
Add support for arrays of before and after handlers

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -54,7 +54,7 @@ module.exports = function(app, route, modelName, model) {
     register: function(app, method, path, callback, last, options) {
       var args = [path];
       if (options && options.before) {
-        before = [].concat options.before
+        before = [].concat(options.before);
         for (var len = before.length, i=0; i<len; ++i) {
           args.push(before[i].bind(this));
         }

--- a/Resource.js
+++ b/Resource.js
@@ -118,8 +118,8 @@ module.exports = function(app, route, modelName, model) {
           default:
             res.status(res.resource.status).json(res.resource.item);
             break;
-          return next();
         }
+        return next();
       }
     },
 

--- a/Resource.js
+++ b/Resource.js
@@ -79,40 +79,46 @@ module.exports = function(app, route, modelName, model) {
     },
 
     /**
-     * The different responses.
+     * Sets the different responses and calls the next middleware for
+     * execution.
+     *
      * @param res
      *   The response to send to the client.
-     *
-     * @returns Response or NULL.
+     * @param next
+     *   The next middleware
      */
     respond: function(req, res, next) {
       if (req.noResponse) { return next(); }
       if (res.resource) {
         switch (res.resource.status) {
           case 400:
-            return res.status(400).json({
+            res.status(400).json({
               status: 400,
               message: res.resource.error.message,
               errors: _.mapValues(res.resource.error.errors, function(error) {
                 return _.pick(error, 'path', 'name', 'message');
               })
             });
+            break;
           case 404:
-            return res.status(404).json({
+            res.status(404).json({
               status: 404,
               errors: ['Resource not found']
             });
+            break;
           case 500:
-            return res.status(500).json({
+            res.status(500).json({
               status: 500,
               message: res.resource.error.message,
               errors: _.mapValues(res.resource.error.errors, function(error) {
                 return _.pick(error, 'path', 'name', 'message');
               })
             });
+            break;
           default:
             res.status(res.resource.status).json(res.resource.item);
-            return next();
+            break;
+          return next();
         }
       }
     },

--- a/Resource.js
+++ b/Resource.js
@@ -85,8 +85,8 @@ module.exports = function(app, route, modelName, model) {
      *
      * @returns Response or NULL.
      */
-    respond: function(req, res) {
-      if (req.noResponse) { return; }
+    respond: function(req, res, next) {
+      if (req.noResponse) { return next(); }
       if (res.resource) {
         switch (res.resource.status) {
           case 400:
@@ -111,7 +111,8 @@ module.exports = function(app, route, modelName, model) {
               })
             });
           default:
-            return res.status(res.resource.status).json(res.resource.item);
+            res.status(res.resource.status).json(res.resource.item);
+            return next();
         }
       }
     },

--- a/Resource.js
+++ b/Resource.js
@@ -61,7 +61,10 @@ module.exports = function(app, route, modelName, model) {
       }
       args.push(callback.bind(this));
       if (options && options.after) {
-        args.push(options.after.bind(this));
+        after = [].concat(options.after);
+        for (var len = after.length, i=0; i<len; ++i) {
+          args.push(after[i].bind(this));
+        }
       }
       args.push(last.bind(this));
 

--- a/Resource.js
+++ b/Resource.js
@@ -54,10 +54,7 @@ module.exports = function(app, route, modelName, model) {
     register: function(app, method, path, callback, last, options) {
       var args = [path];
       if (options && options.before) {
-        before = [].concat options.before
-        for (var len = before.length, i=0; i<len; ++i) {
-          args.push(before[i].bind(this));
-        }
+        args.push(options.before.bind(this));
       }
       args.push(callback.bind(this));
       if (options && options.after) {

--- a/Resource.js
+++ b/Resource.js
@@ -54,7 +54,10 @@ module.exports = function(app, route, modelName, model) {
     register: function(app, method, path, callback, last, options) {
       var args = [path];
       if (options && options.before) {
-        args.push(options.before.bind(this));
+        before = [].concat options.before
+        for (var len = before.length, i=0; i<len; ++i) {
+          args.push(before[i].bind(this));
+        }
       }
       args.push(callback.bind(this));
       if (options && options.after) {


### PR DESCRIPTION
**Problem**
I want to provide multiple, consecutive middleware handlers to be run both `options.before` and `options.after`. Currently `resourcejs` only supports a single handler in each case. 

I could not simply compose the multi-function sequence within the single handler slot because I am post-processing the option handlers and need to inject a new, auto-generated handler that must run first, that is before the `options.before` handler. I also need to inject another auto-generated handler that must run last, that is after `options.after` handler

**Solution**
Treat the `options.before` and `options.after` handlers as arrays. If a single non-array function is provided, convert this to an array before binding the function. The user can now provide a single (non-array) handler function as before or an array of functions. Each element is bound and runs in sequence.

This is not only a generally useful feature, working more like express middleware routing functions, but is also, I believe, crucial if `resourcejs` is to be further automated and manipulated by higher layers.