### PR TITLE
Allow searching objects below the first level with regex.

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -233,7 +233,7 @@ module.exports = function(app, route, modelName, model) {
         var filter = _.zipObject(['name', 'selector'], _.words(name, /[^,_ ]+/g));
 
         // See if this parameter is defined in our model.
-        var param = this.model.schema.paths[filter.name];
+        var param = this.model.schema.paths[filter.name.split('.')[0]];
         if (param) {
 
           // See if there is a selector.


### PR DESCRIPTION
If you have an object property such as "data" on a resource, it isn't possible to use filtering on properties of that object. For example, ?data.field__regex=/test/i doesn't work since data.field is not part of the path for the model.

This change matches the first part of the field (data) against the model paths which should find it.