### PR TITLE
Robblovell patch 1

### DIFF
--- a/Swagger.js
+++ b/Swagger.js
@@ -1,7 +1,21 @@
 var _ = require('lodash');
 var mongoose = require('mongoose');
 module.exports = function(resource, resourceUrl, bodyDefinition) {
-
+  var addNestedIdParameter = function(resource, parameters) {
+    if (resource.route.includes("/:")) {
+      if (resource.route.match(/:(.+)\//).length >= 1 && resource.route.match(/^\/(.+)\/:/).length >= 1) {
+        idName = resource.route.match(/:(.+)\//)[1]
+        primaryModel = resource.route.match(/^\/(.+)\/:/)[1]
+        parameters.push({
+          in: 'path',
+          name: idName,
+          description: 'The parent model of ' + resource.modelName + ': ' + primaryModel,
+          required: true,
+          type: 'string'
+        })
+      }
+    }
+  }
   /**
    * Converts a Mongoose property to a Swagger property.
    *
@@ -215,14 +229,14 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
           type: 'integer',
           default: 10
         },
-        {
-          name: 'count',
-          in: 'query',
-          description: 'Set to true to return the number of records instead of the documents.',
-          type: 'boolean',
-          required: false,
-          default: false
-        },
+        //{
+        //  name: 'count',
+        //  in: 'query',
+        //  description: 'Set to true to return the number of records instead of the documents.',
+        //  type: 'boolean',
+        //  required: false,
+        //  default: false
+        //},
         {
           name: 'sort',
           in: 'query',
@@ -248,7 +262,10 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
           default: ''
         }
       ]
+
     };
+    addNestedIdParameter(resource, swagger.paths[listPath].get.parameters)
+
   }
 
   // POST listPath.
@@ -281,6 +298,8 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
         }
       ]
     };
+    addNestedIdParameter(resource, swagger.paths[listPath].post.parameters)
+
   }
 
   // The resource path for this resource.
@@ -322,6 +341,8 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
         }
       ]
     };
+    addNestedIdParameter(resource, swagger.paths[itemPath].get.parameters)
+
   }
 
   // PUT itemPath
@@ -370,6 +391,8 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
         }
       ]
     };
+    addNestedIdParameter(resource, swagger.paths[itemPath].put.parameters)
+
   }
 
   // DELETE itemPath
@@ -406,6 +429,8 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
         }
       ]
     };
+    addNestedIdParameter(resource, swagger.paths[itemPath].delete.parameters)
+
   }
 
   // Return the swagger definition for this resource.

--- a/Swagger.js
+++ b/Swagger.js
@@ -1,11 +1,26 @@
 var _ = require('lodash');
 var mongoose = require('mongoose');
 module.exports = function(resource, resourceUrl, bodyDefinition) {
+
+  var fixNestedRoutes = function(resource) {
+    routeParts = resource.route.split('/');
+    for (i=0;i<routeParts.length;i++) {
+      if (routeParts[i].charAt(0) == ':') {
+        routeParts[i] = '{' + routeParts[i].slice(1) + '}'
+      }
+    }
+    resource.routeFixed = routeParts.join('/');
+    return resource
+  };
+  resource = fixNestedRoutes(resource);
+
   var addNestedIdParameter = function(resource, parameters) {
     if (resource.route.includes("/:")) {
-      if (resource.route.match(/:(.+)\//).length >= 1 && resource.route.match(/^\/(.+)\/:/).length >= 1) {
-        idName = resource.route.match(/:(.+)\//)[1]
-        primaryModel = resource.route.match(/^\/(.+)\/:/)[1]
+      if (resource.route.match(/:(.+)\//).length >= 1 && resource.route.match(/^\/(.+)\/\:/).length >= 1) {
+
+        idName = resource.route.match(/:(.+)\//)[1];
+        primaryModel = resource.route.match(/^\/(.+)\/\:/)[1];
+
         parameters.push({
           in: 'path',
           name: idName,
@@ -15,7 +30,7 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
         })
       }
     }
-  }
+  };
   /**
    * Converts a Mongoose property to a Swagger property.
    *
@@ -169,7 +184,7 @@ module.exports = function(resource, resourceUrl, bodyDefinition) {
 
   // Build and return a Swagger definition for this model.
 
-  var listPath = resourceUrl || resource.route;
+  var listPath = resourceUrl || resource.routeFixed;
   var itemPath = listPath + '/{' + resource.name + 'Id}';
   bodyDefinition = bodyDefinition || getModel(resource.model.schema);
 


### PR DESCRIPTION
Added support for nested models in the swagger interface.  Now, when you specify a nested model route of the form /parent/:parentId/child, the swagger code will add an 'in path parameter' so that a form entry will be added to the route. Also, the route is changed to /parent/{parentId}/child so that when the form is submitted, the id in the form is replaced in the {} brackets and the call moves forward correctly.

