### PR TITLE
Adding more filter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: node_js
-services: mongodb
 node_js:
+  - "4.2"
   - "4.1"
   - "4.0"
   - "0.12"
   - "0.11"
   - "0.10"
+
+env:
+  - DEBUG=*,*:*
+
+before_script:
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.5.tgz -O /tmp/mongodb.tgz
+  - tar -xvf /tmp/mongodb.tgz
+  - mkdir /tmp/data
+  - ${PWD}/mongodb-linux-x86_64-3.0.5/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
+  - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 5; done

--- a/Resource.js
+++ b/Resource.js
@@ -268,22 +268,24 @@ module.exports = function(app, route, modelName, model) {
               return;
             }
             else {
-
               // Init the filter.
               if (!findQuery.hasOwnProperty(filter.name)) {
                 findQuery[filter.name] = {};
               }
 
               // Set the selector for this filter name.
-              value = (param.instance === 'Number') ? parseInt(value, 10) : value;
+              value = (param.instance === 'Number')
+                ? parseInt(value, 10)
+                : value;
               findQuery[filter.name]['$' + filter.selector] = value;
               return;
             }
           }
           else {
-
             // Set the find query to this value.
-            value = (param.instance === 'Number') ? parseInt(value, 10) : value;
+            value = (param.instance === 'Number')
+              ? parseInt(value, 10)
+              : value;
             findQuery[filter.name] = value;
             return;
           }

--- a/Resource.js
+++ b/Resource.js
@@ -273,10 +273,22 @@ module.exports = function(app, route, modelName, model) {
                 findQuery[filter.name] = {};
               }
 
-              // Set the selector for this filter name.
-              value = (param.instance === 'Number')
-                ? parseInt(value, 10)
-                : value;
+              // Special case for in filter with multiple values.
+              if (filter.selector === 'in' && _.contains(value, ',')) {
+                value = value.split(',');
+                _.map(value, function(item) {
+                  return (param.instance === 'Number')
+                    ? parseInt(item, 10)
+                    : item;
+                });
+              }
+              else {
+                // Set the selector for this filter name.
+                value = (param.instance === 'Number')
+                  ? parseInt(value, 10)
+                  : value;
+              }
+
               findQuery[filter.name]['$' + filter.selector] = value;
               return;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resourcejs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple Express library to reflect Mongoose models to a REST interface.",
   "main": "Resource.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -873,14 +873,13 @@ describe('Test single resource search capabilities', function() {
   it('in search selector', function(done) {
     request(app)
       .get('/test/resource1?age__in=1,5,9,20')
-      //.expect('Content-Range', '0-3/4')
+      .expect('Content-Range', '0-3/4')
       .end(function(err, res) {
         if (err) {
           return done(err);
         }
 
         var response = res.body;
-        console.log(response)
         assert.equal(response.length, 4);
         _.each(response, function(resource) {
           var found = false;

--- a/test/test.js
+++ b/test/test.js
@@ -816,7 +816,88 @@ describe('Test single resource search capabilities', function() {
       });
   });
 
-  it('$lt selector', function(done) {
+  it('eq search selector', function(done) {
+    request(app)
+      .get('/test/resource1?age__eq=5')
+      .expect('Content-Range', '0-0/1')
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        var response = res.body;
+        assert.equal(response.length, 1);
+        _.each(response, function(resource) {
+          assert.equal(resource.age, 5);
+        });
+        done();
+      });
+  });
+
+  it('equals (alternative) search selector', function(done) {
+    request(app)
+      .get('/test/resource1?age=5')
+      .expect('Content-Range', '0-0/1')
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        var response = res.body;
+        assert.equal(response.length, 1);
+        _.each(response, function(resource) {
+          assert.equal(resource.age, 5);
+        });
+        done();
+      });
+  });
+
+  it('ne search selector', function(done) {
+    request(app)
+      .get('/test/resource1?age__ne=5&limit=100')
+      .expect('Content-Range', '0-23/24')
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        var response = res.body;
+        assert.equal(response.length, 24);
+        _.each(response, function(resource) {
+          assert.notEqual(resource.age, 5);
+        });
+        done();
+      });
+  });
+
+  it('in search selector', function(done) {
+    request(app)
+      .get('/test/resource1?age__in=1,5,9,20')
+      //.expect('Content-Range', '0-3/4')
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        var response = res.body;
+        console.log(response)
+        assert.equal(response.length, 4);
+        _.each(response, function(resource) {
+          var found = false;
+
+          [1,5,9,20].forEach(function(a) {
+            if (resource.age && resource.age === a) {
+              found = true;
+            }
+          });
+
+          assert(found);
+        });
+        done();
+      });
+  });
+
+  it('lt search selector', function(done) {
     request(app)
       .get('/test/resource1?age__lt=5')
       .expect('Content-Range', '0-4/5')
@@ -834,7 +915,7 @@ describe('Test single resource search capabilities', function() {
       });
   });
 
-  it('$lte selector', function(done) {
+  it('lte search selector', function(done) {
     request(app)
       .get('/test/resource1?age__lte=5')
       .expect('Content-Range', '0-5/6')
@@ -852,7 +933,7 @@ describe('Test single resource search capabilities', function() {
       });
   });
 
-  it('$gt selector', function(done) {
+  it('gt search selector', function(done) {
     request(app)
       .get('/test/resource1?age__gt=5')
       .expect('Content-Range', '0-9/19')
@@ -870,7 +951,7 @@ describe('Test single resource search capabilities', function() {
       });
   });
 
-  it('$gte selector', function(done) {
+  it('gte search selector', function(done) {
     request(app)
       .get('/test/resource1?age__gte=5')
       .expect('Content-Range', '0-9/20')
@@ -888,7 +969,7 @@ describe('Test single resource search capabilities', function() {
       });
   });
 
-  it('regex selector', function(done) {
+  it('regex search selector', function(done) {
     request(app)
       .get('/test/resource1?title__regex=/.*Age [0-1]?[0-3]$/g')
       .expect('Content-Range', '0-7/8')

--- a/test/test.js
+++ b/test/test.js
@@ -819,7 +819,8 @@ describe('Test single resource search capabilities', function() {
   it('eq search selector', function(done) {
     request(app)
       .get('/test/resource1?age__eq=5')
-      .expect('Content-Range', '0-0/1')
+      .expect('Content-Type', /json/)
+      .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
@@ -837,7 +838,8 @@ describe('Test single resource search capabilities', function() {
   it('equals (alternative) search selector', function(done) {
     request(app)
       .get('/test/resource1?age=5')
-      .expect('Content-Range', '0-0/1')
+      .expect('Content-Type', /json/)
+      .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
@@ -855,7 +857,8 @@ describe('Test single resource search capabilities', function() {
   it('ne search selector', function(done) {
     request(app)
       .get('/test/resource1?age__ne=5&limit=100')
-      .expect('Content-Range', '0-23/24')
+      .expect('Content-Type', /json/)
+      .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);
@@ -873,7 +876,8 @@ describe('Test single resource search capabilities', function() {
   it('in search selector', function(done) {
     request(app)
       .get('/test/resource1?age__in=1,5,9,20')
-      .expect('Content-Range', '0-3/4')
+      .expect('Content-Type', /json/)
+      .expect(200)
       .end(function(err, res) {
         if (err) {
           return done(err);


### PR DESCRIPTION
Adding filter tests for:
 - eq
 - ne
 - in

Added fix for mongo `$in` filter not properly parsing out individual values.

Added Node 4.2 (LTS) to the test list. Forcing mongo 3.0.5 in build env.