### PR TITLE
Add missing comma in first example's resource schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var ResourceSchema = new mongoose.Schema({
   },
   description: {
     type: String
-  }
+  },
   count: {
     type: Number
   }


### PR DESCRIPTION
This was inducing  a `SyntaxError: Unexpected token`