### PR TITLE
Allow in and nin operators to work on single values as well as multip…

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -289,7 +289,7 @@ module.exports = function(app, route, modelName, model) {
                 value = !!value;
               }
               // Special case for in filter with multiple values.
-              else if ((_.indexOf(['in', 'nin'], filter.selector) !== -1) && _.includes(value, ',')) {
+              else if ((_.indexOf(['in', 'nin'], filter.selector) !== -1)) {
                 value = value.split(',');
                 _.map(value, function(item) {
                   return (param.instance === 'Number')


### PR DESCRIPTION
…les. Currently throws a mongo error that value isn't an array.

For example, this is not valid:
?tags__in=test

while this is:
?tags__in=test,another

When the number of items to check is variable, there may only be one sometimes. Checking for a comma is unnecessary as "test".split(',') will return ["test"] which is what mongodb wants.