### PR TITLE
Swagger Fix for embedded schemas.

### DIFF
--- a/Swagger.js
+++ b/Swagger.js
@@ -68,7 +68,15 @@ module.exports = function(resource) {
         }
       };
     }
-
+    // For embedded schemas:
+    if (options.type.constructor.name === 'Schema') {
+      if (options.type.hasOwnProperty('paths')) {
+        return {
+          $ref: '#/definitions/' + name,
+          definitions: getModel(options.type, name)
+        };
+      }
+    }
     if (typeof options.type === 'function') {
       var functionName = options.type.toString();
       functionName = functionName.substr('function '.length);

--- a/test/test.js
+++ b/test/test.js
@@ -143,7 +143,8 @@ describe('Build Resources for following tests', function() {
       description: {
         type: String
       },
-      list: [R1SubdocumentSchema]
+      list: [R1SubdocumentSchema],
+      list2: [String]
     });
 
     // Create the model.
@@ -773,7 +774,7 @@ describe('Test single resource search capabilities', function() {
 
   it('Should not populate paths that are not a reference', function(done) {
     request(app)
-      .get('/test/resource1?name=noage&populate=list')
+      .get('/test/resource1?name=noage&populate=list2')
       .end(function(err, res) {
         if (err) {
           return done(err);


### PR DESCRIPTION
If an embedded schema is given, this makes the example model register correctly in swagger.

This is a fix for issue #63
