### PR TITLE
Add ability to pass options to underlying `.save()` and `.remove()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,20 @@ Resource(app, '', 'user', UserModel).rest({
 });
 ```
 
+Passing write options on PUT, POST, PATCH, and DELETE requests
+--------------------------------------------------------------
+It is possible to pass a set of options to the underlying `Document.save()` and `Document.remove()` commands. This can be useful when plugins expect data to be passed in as options. We can do this by adding a ***writeOptions*** object to the ***req*** object during middleware. This uses the Mongoose mechanism that you can see here https://mongoosejs.com/docs/api.html#document_Document-save.
+
+For example, a set of options can be added by doing the following.
+
+```javascript
+Resource(app, '', 'user', UserModel).rest({
+  before: function(req, res, next) {
+    req.writeOptions = { actingUserId: req.user.id };
+  }
+});
+```
+
 Nested Resources
 -----------------
 With this library, it is also pretty easy to nest resources. Here is an example of how to do it.


### PR DESCRIPTION
Clients can use a `before` hook to pass specific options down to the underlying `Document.save()` or `Document.remove()` call, which is useful for some Mongoose plugins.

It's nice that the code already used `Document.save()`, which supports options and fires hooks. This change also makes DELETE requests user `Document.remove()` instead of `Query.remove()`, so `remove` hooks will be fired as well.

Would love any feedback on if this is a good approach, and well as any pointers of how best to add tests for this.