### PR TITLE
Merging `before` and `before[Method]` handlers

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -193,19 +193,13 @@ class Resource {
     const methodOptions = { methodOptions: true };
 
     // Find all of the options that may have been passed to the rest method.
-    if (options.before) {
-      methodOptions.before = options.before;
-    }
-    else if (options.hasOwnProperty(`before${method}`)) {
-      methodOptions.before = options[`before${method}`];
-    }
+    const beforeHandlers = options.before || [];
+    const beforeMethodHandlers = options[`before${method}`] || [];
+    methodOptions.before = _.concat(beforeHandlers, beforeMethodHandlers);
 
-    if (options.after) {
-      methodOptions.after = options.after;
-    }
-    else if (options.hasOwnProperty(`after${method}`)) {
-      methodOptions.after = options[`after${method}`];
-    }
+    const afterHandlers = options.after || [];
+    const afterMethodHandlers = options[`after${method}`] || [];
+    methodOptions.after = _.concat(afterHandlers, afterMethodHandlers);
 
     // Expose mongoose hooks for each method.
     ['before', 'after'].forEach((type) => {

--- a/test/test.js
+++ b/test/test.js
@@ -186,9 +186,19 @@ describe('Build Resources for following tests', () => {
         setInvoked('resource2', 'before', req);
         next();
       },
+      beforePost(req, res, next) {
+        // Store the invoked handler and continue.
+        setInvoked('resource2', 'beforePost', req);
+        next();
+      },
       after(req, res, next) {
         // Store the invoked handler and continue.
         setInvoked('resource2', 'after', req);
+        next();
+      },
+      afterPost(req, res, next) {
+        // Store the invoked handler and continue.
+        setInvoked('resource2', 'afterPost', req);
         next();
       },
     });
@@ -1257,7 +1267,7 @@ describe('Test single resource handlers capabilities', () => {
   // Store the resource being mutated.
   let resource = {};
 
-  it('A POST request should invoke the global handlers', () => request(app)
+  it('A POST request should invoke the global handlers and method handlers', () => request(app)
     .post('/test/resource2')
     .send({
       title: 'Test1',
@@ -1274,6 +1284,8 @@ describe('Test single resource handlers capabilities', () => {
       // Confirm that the handlers were called.
       assert.equal(wasInvoked('resource2', 'before', 'post'), true);
       assert.equal(wasInvoked('resource2', 'after', 'post'), true);
+      assert.equal(wasInvoked('resource2', 'beforePost', 'post'), true);
+      assert.equal(wasInvoked('resource2', 'afterPost', 'post'), true);
 
       // Store the resource and continue.
       resource = response;
@@ -1292,6 +1304,10 @@ describe('Test single resource handlers capabilities', () => {
       // Confirm that the handlers were called.
       assert.equal(wasInvoked('resource2', 'before', 'get'), true);
       assert.equal(wasInvoked('resource2', 'after', 'get'), true);
+
+      // Confirm that POST method handlers were NOT called
+      assert.equal(wasInvoked('resource2', 'beforePost', 'get'), false);
+      assert.equal(wasInvoked('resource2', 'afterPost', 'get'), false);
 
       // Store the resource and continue.
       resource = response;


### PR DESCRIPTION
Fixes #91

I'd like to write more comprehensive tests for `getMethodOptions` directly. To make that easier, `getMethodOptions` should be a static function. It should also be a static function since it doesn't use `this`. I figured I'd break that out into another PR.