### PR TITLE
Return 400 if an error occurs in request middleware.

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -77,8 +77,8 @@ class Resource {
     // Add a fallback error handler.
     mw.use((err, req, res, next) => {
       if (err) {
-        res.status(500).json({
-          status: 500,
+        res.status(400).json({
+          status: 400,
           message: err.message || err,
         });
       }


### PR DESCRIPTION
500 errors indicate there is a server side error (something went wrong with the server) when in reality most of these errors are a problem with the request and should be a 400 error. 500s tend to take down the server since monitoring software treats it as a server that has gone bad.