### PR TITLE
Improve swagger schema that includes an array of types

### DIFF
--- a/Swagger.js
+++ b/Swagger.js
@@ -230,12 +230,6 @@ module.exports = function(resource) {
 
   // Build Swagger definitions.
   swagger.definitions = _.merge(swagger.definitions, bodyDefinitions);
-  swagger.definitions[resource.modelName + 'List'] = {
-    type: 'array',
-      items: {
-        $ref: '#/definitions/' + resource.modelName,
-      }
-  };
 
   // Build Swagger paths
   var methods = resource.methods;
@@ -258,7 +252,10 @@ module.exports = function(resource) {
         200: {
           description: 'Resource(s) found.  Returned as array.',
           schema: {
-            $ref: "#/definitions/" + resource.modelName + "List"
+            type: "array",
+            items: {
+              $ref: "#/definitions/" + resource.modelName
+            }
           }
         }
       },


### PR DESCRIPTION
I am starting to work with Form.io API. In order to call api, we use library swagger codegen (https://github.com/swagger-api/swagger-codegen).

But it seems that the spec.json does not provide a valid swagger json concerning resource lists management.
 
To date, resource lists are managed like this : 
```
"summary": "List multiple user resources.",
"description": "This operation allows you to list and search for user resources provided query arguments.",
"operationId": "getusers",
"responses": {
"200": {
"description": "Resource(s) found.  Returned as array.",
"schema": {
"$ref": "#/definitions/userList"
}
```

with associated definition : 
```
"userList": {
"type": "array",
"items": {
"$ref": "#/definitions/user"
}
```

Using swagger codegen tool, it generates empty ResouceModelList model : 
```
/**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @var string[]
      */
    protected static $swaggerTypes = [
        
    ];

    /**
      * Array of property to format mappings. Used for (de)serialization
      *
      * @var string[]
      */
    protected static $swaggerFormats = [
        
    ];
```

This results in not being able to deserialize the list of resources.

My PR fix problem.