### PR TITLE
Coveralls, Virtual Improvements, Removal of Lodash and Middleware in favor of ES6 and EspressJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 .log
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 node_modules
 .log
+.nyc_output
 coverage

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,18 @@
+  
+'use strict';
+
+// Here's a JavaScript-based config file.
+// If you need conditional logic, you might want to use this type of config.
+// Otherwise, JSON or YAML is recommended.
+
+module.exports = {
+  diff: true,
+  extension: ['js'],
+  opts: false,
+  package: './package.json',
+  reporter: 'spec',
+  slow: 75,
+  timeout: 2000,
+  ui: 'bdd',
+  'watch-files': ['test/**/*.js']
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ node_js:
   - "12"
   - "10"
 
-env:
-  - DEBUG=*
-
 script:
   - echo "Running tests against $(node -v)..."
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
+  - "13"
   - "12"
   - "10"
-  - "8"
-  - "6"
 
 env:
   - DEBUG=*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "8"
   - "6"
@@ -7,9 +8,13 @@ node_js:
 env:
   - DEBUG=*
 
-before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.1.tgz -O /tmp/mongodb.tgz
-  - tar -xvf /tmp/mongodb.tgz
-  - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
-  - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 5; done
+script:
+  - echo "Running tests against $(node -v)..."
+  - npm run test
+
+after_script:
+  - npm run coverage
+  - cat ./coverage/lcov.info | coveralls
+
+services:
+  - mongodb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-[![Build Status](https://travis-ci.org/travist/resourcejs.svg?branch=master)](https://travis-ci.org/travist/resourcejs)
 Resource.js - A simple Express library to reflect Mongoose models to a REST interface with a splash of Swagger.io love.
 ==============================================================
+[![NPM version][npm-image]][npm-url]
+[![NPM download][download-image]][download-url]
+[![Build Status](https://travis-ci.org/travist/resourcejs.svg?branch=master)](https://travis-ci.org/travist/resourcejs)
+[![Coverage Status](https://coveralls.io/repos/github/Sefriol/resourcejs/badge.svg?branch=master)](https://coveralls.io/github/Sefriol/resourcejs?branch=master)
+
+[npm-image]: https://img.shields.io/npm/v/resourcejs.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/resourcejs
+[download-image]: https://img.shields.io/npm/dm/resourcejs.svg?style=flat-square
+[download-url]: https://npmjs.org/package/resourcejs
 
 Resource.js is designed to be a minimalistic Express library that reflects a Mongoose
 model to a RESTful interface. It does this through a very simple and extensible interface.

--- a/Resource.js
+++ b/Resource.js
@@ -772,8 +772,8 @@ class Resource {
           patches.forEach((patch) => {
             if (patch.op === 'test') {
               patchFail = patch;
-              const success = jsonpatch.applyPatch(item, [].concat(patch), true);
-              if (!success || !success.length) {
+              const success = jsonpatch.applyOperation(item, patch, true);
+              if (!success || !success.test) {
                 return Resource.setResponse(res, {
                   status: 412,
                   name: 'Precondition Failed',

--- a/Resource.js
+++ b/Resource.js
@@ -72,8 +72,10 @@ class Resource {
       routeStack = [...routeStack, ...after];
     }
 
+    routeStack = [...routeStack, last.bind(this)];
+
     // Add a fallback error handler.
-    this.app.use(path, (err, req, res, next) => {
+    const error = (err, req, res, next) => {
       if (err) {
         res.status(400).json({
           status: 400,
@@ -83,7 +85,9 @@ class Resource {
       else {
         return next();
       }
-    });
+    };
+
+    routeStack = [...routeStack, error.bind(this)]
 
     // Declare the resourcejs object on the app.
     if (!this.app.resourcejs) {
@@ -100,19 +104,19 @@ class Resource {
     // Apply these callbacks to the application.
     switch (method) {
       case 'get':
-        this.app.get(path, routeStack, last.bind(this));
+        this.app.get(path, routeStack);
         break;
       case 'post':
-        this.app.post(path, routeStack, last.bind(this));
+        this.app.post(path, routeStack);
         break;
       case 'put':
-        this.app.put(path, routeStack, last.bind(this));
+        this.app.put(path, routeStack);
         break;
       case 'patch':
-        this.app.patch(path, routeStack, last.bind(this));
+        this.app.patch(path, routeStack);
         break;
       case 'delete':
-        this.app.delete(path, routeStack, last.bind(this));
+        this.app.delete(path, routeStack);
         break;
     }
   }

--- a/Resource.js
+++ b/Resource.js
@@ -626,7 +626,7 @@ class Resource {
     if (!options || !options.path || !options.before) return this;
     const path = options.path;
     options = Resource.getMethodOptions('virtual', options);
-    this.methods.push('virtual');
+    this.methods.push(`virtual/${path}`);
     this._register('get', `${this.route}/virtual/${path}`, (req, res, next) => {
       // Store the internal method for response manipulation.
       req.__rMethod = 'virtual';

--- a/Swagger.js
+++ b/Swagger.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 module.exports = function(resource) {
   const fixNestedRoutes = function(resource) {
     const routeParts = resource.route.split('/');
@@ -152,8 +150,7 @@ module.exports = function(resource) {
       properties: {},
     };
     // Iterate through each model schema path.
-    _.each(schema.paths, function(path, name) {
-
+    Object.entries(schema.paths).forEach(([name, path]) => {
       // Set the property for the swagger model.
       const property = getProperty(path, name);
       if (name.substr(0, 2) !== '__' && property) {
@@ -199,7 +196,7 @@ module.exports = function(resource) {
 
         // Allow properties to pass back additional definitions.
         if (property.definitions) {
-          definitions = _.merge(definitions, property.definitions);
+          definitions = Object.assign(definitions, property.definitions);
           delete property.definitions;
         }
 
@@ -223,7 +220,7 @@ module.exports = function(resource) {
   };
 
   // Build Swagger definitions.
-  swagger.definitions = _.merge(swagger.definitions, bodyDefinitions);
+  swagger.definitions = Object.assign(swagger.definitions, bodyDefinitions);
 
   // Build Swagger paths
   const methods = resource.methods;
@@ -248,7 +245,7 @@ module.exports = function(resource) {
             type: 'array',
             items: {
               $ref: `#/definitions/${  resource.modelName}`,
-      },
+            },
           },
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -704,11 +704,6 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
-    "composable-middleware": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/composable-middleware/-/composable-middleware-0.3.0.tgz",
-      "integrity": "sha1-JYyUYunQ6eMhM/cmDuJRWdDbvgk="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2062,7 +2062,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -396,6 +396,21 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -408,11 +423,32 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -528,6 +564,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
@@ -736,6 +778,27 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "coveralls": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -747,6 +810,15 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -823,6 +895,16 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -1106,6 +1188,12 @@
         "tmp": "^0.0.33"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -1287,6 +1375,12 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -1359,6 +1453,15 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1402,6 +1505,22 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -1457,6 +1576,17 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1653,6 +1783,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -1831,10 +1967,22 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1847,6 +1995,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -1866,10 +2020,28 @@
         }
       }
     },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "kareem": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+      "dev": true
+    },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
     },
     "levn": {
@@ -1901,6 +2073,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -2418,6 +2596,12 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -2589,6 +2773,12 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
@@ -2676,6 +2866,12 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2755,6 +2951,53 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -3031,6 +3274,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -3261,10 +3521,43 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -3344,6 +3637,17 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,15 +1109,13 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1"
-      }
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,103 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -23,6 +120,167 @@
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@babel/parser": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.4",
+        "@babel/types": "^7.8.3",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.7",
@@ -45,6 +303,16 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -97,6 +365,21 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -223,6 +506,18 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
     },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -273,6 +568,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -349,6 +650,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -388,6 +695,23 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "cookie": {
       "version": "0.4.0",
@@ -444,6 +768,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -539,6 +872,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -851,6 +1190,17 @@
         }
       }
     },
+    "find-cache-dir": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+      "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.0",
+        "pkg-dir": "^4.1.0"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -886,6 +1236,59 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -915,6 +1318,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "fromentries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -938,6 +1347,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true
     },
     "get-caller-file": {
@@ -978,6 +1393,12 @@
         "type-fest": "^0.8.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -1005,10 +1426,26 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "hasha": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
     },
     "http-errors": {
@@ -1061,6 +1498,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -1174,6 +1617,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -1182,6 +1631,18 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -1193,6 +1654,168 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1210,6 +1833,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1221,6 +1850,23 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "kareem": {
       "version": "2.3.1",
@@ -1253,6 +1899,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -1260,6 +1912,23 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "make-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "media-typer": {
@@ -1434,9 +2103,9 @@
       }
     },
     "mongoose": {
-      "version": "5.8.11",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.11.tgz",
-      "integrity": "sha512-Yz0leNEJsAtNtMTxTDEadacLWt58gaVeBVL3c1Z3vaBoc159aJqlf+T8jaL9mAdBxKndF5YWhh6Q719xac7cjA==",
+      "version": "5.8.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.13.tgz",
+      "integrity": "sha512-YUBykYbx8/PMR1N8xAxl81PU+JQuMx5pVp7eHelifUMazshQqIwvToUtIxlinEG3NYbbS9FTSzYBrbBLDfrADQ==",
       "dev": true,
       "requires": {
         "bson": "~1.1.1",
@@ -1564,11 +2233,192 @@
       "resolved": "https://registry.npmjs.org/node-paginate-anything/-/node-paginate-anything-1.0.0.tgz",
       "integrity": "sha1-WR/jCw1r8J/7yrl9ETt2z6mdHZs="
     },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "nyc": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
+      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.0",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "uuid": "^3.3.3",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1669,11 +2519,32 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -1708,6 +2579,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -1720,6 +2597,51 @@
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1730,6 +2652,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
     },
     "progress": {
       "version": "2.0.3",
@@ -1819,6 +2750,15 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1838,6 +2778,15 @@
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -2029,6 +2978,12 @@
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -2036,6 +2991,40 @@
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+          "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "sprintf-js": {
@@ -2123,6 +3112,12 @@
           "dev": true
         }
       }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -2215,6 +3210,17 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2235,6 +3241,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -2282,6 +3294,15 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2306,6 +3327,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -2432,6 +3459,18 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+      "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/travist/resourcejs",
   "dependencies": {
-    "composable-middleware": "^0.3.0",
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "body-parser": "^1.19.0",
     "chance": "^1.1.3",
+    "coveralls": "^3.0.9",
     "eslint": "^6.8.0",
     "eslint-config-formio": "^1.1.4",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A simple Express library to reflect Mongoose models to a REST interface.",
   "main": "Resource.js",
   "scripts": {
-    "test": "mocha test/test.js -t 2000 --exit",
-    "coverage": "nyc --reporter=lcov --report-dir=./coverage npm run test ",
+    "test": "mocha --opts test/mocha.opts",
+    "coverage": "nyc --reporter=lcov --report-dir=./coverage npm run test",
     "lint": "eslint Resource.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple Express library to reflect Mongoose models to a REST interface.",
   "main": "Resource.js",
   "scripts": {
-    "test": "mocha --opts test/mocha.opts",
+    "test": "mocha --exit",
     "coverage": "nyc --reporter=lcov --report-dir=./coverage npm run test",
     "lint": "eslint Resource.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple Express library to reflect Mongoose models to a REST interface.",
   "main": "Resource.js",
   "scripts": {
-    "test": "mocha test/test.js -b -t 30000 --exit",
+    "test": "mocha test/test.js -t 2000 --exit",
+    "coverage": "nyc --reporter=lcov --report-dir=./coverage npm run test ",
     "lint": "eslint Resource.js"
   },
   "repository": {
@@ -40,6 +41,7 @@
     "express": "^4.17.1",
     "mocha": "^7.0.1",
     "mongoose": "^5.8.11",
+    "nyc": "^15.0.0",
     "supertest": "^4.0.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "composable-middleware": "^0.3.0",
     "debug": "^4.1.1",
-    "fast-json-patch": "^2.2.1",
+    "fast-json-patch": "^3.0.0-1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "mongodb": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
-    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "mongodb": "^3.5.3",
     "node-paginate-anything": "^1.0.0"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,0 @@
-./test/test.js
---recursive
---reporter spec
---timeout 2000
---exit

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+./test/test.js
+--recursive
+--reporter spec
+--timeout 2000
+--exit

--- a/test/snippets/dateSwaggerio.json
+++ b/test/snippets/dateSwaggerio.json
@@ -1,0 +1,177 @@
+{
+  "definitions": {
+    "date": {
+      "title": "date",
+      "properties": {
+        "date": { "type": "string", "format": "date" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/date": {
+      "get": {
+        "tags": ["date"],
+        "summary": "List multiple date resources.",
+        "description": "This operation allows you to list and search for date resources provided query arguments.",
+        "operationId": "getdates",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/date" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["date"],
+        "summary": "Create a new date",
+        "description": "Create a new date",
+        "operationId": "createdate",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new date",
+            "required": true,
+            "schema": { "$ref": "#/definitions/date" }
+          }
+        ]
+      }
+    },
+    "/test/date/{dateId}": {
+      "get": {
+        "tags": ["date"],
+        "summary": "Return a specific date instance.",
+        "description": "Return a specific date instance.",
+        "operationId": "getdate",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/date" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "dateId",
+            "in": "path",
+            "description": "The ID of the date that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["date"],
+        "summary": "Update a specific date instance.",
+        "description": "Update a specific date instance.",
+        "operationId": "updatedate",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/date" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "dateId",
+            "in": "path",
+            "description": "The ID of the date that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update date",
+            "required": true,
+            "schema": { "$ref": "#/definitions/date" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["date"],
+        "summary": "Delete a specific date",
+        "description": "Delete a specific date",
+        "operationId": "deletedate",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "dateId",
+            "in": "path",
+            "description": "The ID of the date that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/nested1Swaggerio.json
+++ b/test/snippets/nested1Swaggerio.json
@@ -1,0 +1,215 @@
+{
+  "definitions": {
+    "nested1": {
+      "title": "nested1",
+      "properties": {
+        "resource1": { "type": "string", "description": "ObjectId" },
+        "title": { "type": "string" },
+        "age": { "type": "integer", "format": "int64" },
+        "description": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource1/{resource1Id}/nested1": {
+      "get": {
+        "tags": ["nested1"],
+        "summary": "List multiple nested1 resources.",
+        "description": "This operation allows you to list and search for nested1 resources provided query arguments.",
+        "operationId": "getnested1s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/nested1" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "in": "path",
+            "name": "resource1Id",
+            "description": "The parent model of nested1: test/resource1",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "tags": ["nested1"],
+        "summary": "Create a new nested1",
+        "description": "Create a new nested1",
+        "operationId": "createnested1",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new nested1",
+            "required": true,
+            "schema": { "$ref": "#/definitions/nested1" }
+          },
+          {
+            "in": "path",
+            "name": "resource1Id",
+            "description": "The parent model of nested1: test/resource1",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/test/resource1/{resource1Id}/nested1/{nested1Id}": {
+      "get": {
+        "tags": ["nested1"],
+        "summary": "Return a specific nested1 instance.",
+        "description": "Return a specific nested1 instance.",
+        "operationId": "getnested1",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/nested1" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested1Id",
+            "in": "path",
+            "description": "The ID of the nested1 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "resource1Id",
+            "description": "The parent model of nested1: test/resource1",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["nested1"],
+        "summary": "Update a specific nested1 instance.",
+        "description": "Update a specific nested1 instance.",
+        "operationId": "updatenested1",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/nested1" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested1Id",
+            "in": "path",
+            "description": "The ID of the nested1 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update nested1",
+            "required": true,
+            "schema": { "$ref": "#/definitions/nested1" }
+          },
+          {
+            "in": "path",
+            "name": "resource1Id",
+            "description": "The parent model of nested1: test/resource1",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["nested1"],
+        "summary": "Delete a specific nested1",
+        "description": "Delete a specific nested1",
+        "operationId": "deletenested1",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested1Id",
+            "in": "path",
+            "description": "The ID of the nested1 that will be deleted.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "resource1Id",
+            "description": "The parent model of nested1: test/resource1",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/nested2Swaggerio.json
+++ b/test/snippets/nested2Swaggerio.json
@@ -1,0 +1,215 @@
+{
+  "definitions": {
+    "nested2": {
+      "title": "nested2",
+      "properties": {
+        "resource2": { "type": "string", "description": "ObjectId" },
+        "title": { "type": "string" },
+        "age": { "type": "integer", "format": "int64" },
+        "description": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource2/{resource2Id}/nested2": {
+      "get": {
+        "tags": ["nested2"],
+        "summary": "List multiple nested2 resources.",
+        "description": "This operation allows you to list and search for nested2 resources provided query arguments.",
+        "operationId": "getnested2s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/nested2" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "in": "path",
+            "name": "resource2Id",
+            "description": "The parent model of nested2: test/resource2",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "tags": ["nested2"],
+        "summary": "Create a new nested2",
+        "description": "Create a new nested2",
+        "operationId": "createnested2",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new nested2",
+            "required": true,
+            "schema": { "$ref": "#/definitions/nested2" }
+          },
+          {
+            "in": "path",
+            "name": "resource2Id",
+            "description": "The parent model of nested2: test/resource2",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/test/resource2/{resource2Id}/nested2/{nested2Id}": {
+      "get": {
+        "tags": ["nested2"],
+        "summary": "Return a specific nested2 instance.",
+        "description": "Return a specific nested2 instance.",
+        "operationId": "getnested2",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/nested2" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested2Id",
+            "in": "path",
+            "description": "The ID of the nested2 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "resource2Id",
+            "description": "The parent model of nested2: test/resource2",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["nested2"],
+        "summary": "Update a specific nested2 instance.",
+        "description": "Update a specific nested2 instance.",
+        "operationId": "updatenested2",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/nested2" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested2Id",
+            "in": "path",
+            "description": "The ID of the nested2 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update nested2",
+            "required": true,
+            "schema": { "$ref": "#/definitions/nested2" }
+          },
+          {
+            "in": "path",
+            "name": "resource2Id",
+            "description": "The parent model of nested2: test/resource2",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["nested2"],
+        "summary": "Delete a specific nested2",
+        "description": "Delete a specific nested2",
+        "operationId": "deletenested2",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "nested2Id",
+            "in": "path",
+            "description": "The ID of the nested2 that will be deleted.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "resource2Id",
+            "description": "The parent model of nested2: test/resource2",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/resource1Swaggerio.json
+++ b/test/snippets/resource1Swaggerio.json
@@ -1,0 +1,193 @@
+{
+  "definitions": {
+    "resource1": {
+      "title": "resource1",
+      "properties": {
+        "title": { "type": "string" },
+        "name": { "type": "string" },
+        "age": { "type": "integer", "format": "int64" },
+        "description": { "type": "string" },
+        "list": {
+          "type": "array",
+          "title": "list",
+          "items": { "$ref": "#/definitions/list" }
+        },
+        "list2": { "type": "array", "items": { "type": "string" } },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    },
+    "list": {
+      "title": "list",
+      "properties": {
+        "label": { "type": "string" },
+        "data": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource1": {
+      "get": {
+        "tags": ["resource1"],
+        "summary": "List multiple resource1 resources.",
+        "description": "This operation allows you to list and search for resource1 resources provided query arguments.",
+        "operationId": "getresource1s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/resource1" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["resource1"],
+        "summary": "Create a new resource1",
+        "description": "Create a new resource1",
+        "operationId": "createresource1",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new resource1",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource1" }
+          }
+        ]
+      }
+    },
+    "/test/resource1/{resource1Id}": {
+      "get": {
+        "tags": ["resource1"],
+        "summary": "Return a specific resource1 instance.",
+        "description": "Return a specific resource1 instance.",
+        "operationId": "getresource1",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/resource1" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource1Id",
+            "in": "path",
+            "description": "The ID of the resource1 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["resource1"],
+        "summary": "Update a specific resource1 instance.",
+        "description": "Update a specific resource1 instance.",
+        "operationId": "updateresource1",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/resource1" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource1Id",
+            "in": "path",
+            "description": "The ID of the resource1 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update resource1",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource1" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["resource1"],
+        "summary": "Delete a specific resource1",
+        "description": "Delete a specific resource1",
+        "operationId": "deleteresource1",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource1Id",
+            "in": "path",
+            "description": "The ID of the resource1 that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/resource2Swaggerio.json
+++ b/test/snippets/resource2Swaggerio.json
@@ -1,0 +1,181 @@
+{
+  "definitions": {
+    "resource2": {
+      "title": "resource2",
+      "properties": {
+        "title": { "type": "string" },
+        "age": { "type": "integer", "format": "int64" },
+        "married": { "type": "boolean" },
+        "updated": { "type": "integer", "format": "int64" },
+        "description": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource2": {
+      "get": {
+        "tags": ["resource2"],
+        "summary": "List multiple resource2 resources.",
+        "description": "This operation allows you to list and search for resource2 resources provided query arguments.",
+        "operationId": "getresource2s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/resource2" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["resource2"],
+        "summary": "Create a new resource2",
+        "description": "Create a new resource2",
+        "operationId": "createresource2",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new resource2",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource2" }
+          }
+        ]
+      }
+    },
+    "/test/resource2/{resource2Id}": {
+      "get": {
+        "tags": ["resource2"],
+        "summary": "Return a specific resource2 instance.",
+        "description": "Return a specific resource2 instance.",
+        "operationId": "getresource2",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/resource2" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource2Id",
+            "in": "path",
+            "description": "The ID of the resource2 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["resource2"],
+        "summary": "Update a specific resource2 instance.",
+        "description": "Update a specific resource2 instance.",
+        "operationId": "updateresource2",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/resource2" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource2Id",
+            "in": "path",
+            "description": "The ID of the resource2 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update resource2",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource2" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["resource2"],
+        "summary": "Delete a specific resource2",
+        "description": "Delete a specific resource2",
+        "operationId": "deleteresource2",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource2Id",
+            "in": "path",
+            "description": "The ID of the resource2 that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/resource3Swaggerio.json
+++ b/test/snippets/resource3Swaggerio.json
@@ -1,0 +1,178 @@
+{
+  "definitions": {
+    "resource3": {
+      "title": "resource3",
+      "properties": {
+        "title": { "type": "string" },
+        "writeOption": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource3": {
+      "get": {
+        "tags": ["resource3"],
+        "summary": "List multiple resource3 resources.",
+        "description": "This operation allows you to list and search for resource3 resources provided query arguments.",
+        "operationId": "getresource3s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/resource3" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["resource3"],
+        "summary": "Create a new resource3",
+        "description": "Create a new resource3",
+        "operationId": "createresource3",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new resource3",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource3" }
+          }
+        ]
+      }
+    },
+    "/test/resource3/{resource3Id}": {
+      "get": {
+        "tags": ["resource3"],
+        "summary": "Return a specific resource3 instance.",
+        "description": "Return a specific resource3 instance.",
+        "operationId": "getresource3",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/resource3" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource3Id",
+            "in": "path",
+            "description": "The ID of the resource3 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["resource3"],
+        "summary": "Update a specific resource3 instance.",
+        "description": "Update a specific resource3 instance.",
+        "operationId": "updateresource3",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/resource3" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource3Id",
+            "in": "path",
+            "description": "The ID of the resource3 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update resource3",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource3" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["resource3"],
+        "summary": "Delete a specific resource3",
+        "description": "Delete a specific resource3",
+        "operationId": "deleteresource3",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource3Id",
+            "in": "path",
+            "description": "The ID of the resource3 that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/resource4Swaggerio.json
+++ b/test/snippets/resource4Swaggerio.json
@@ -1,0 +1,178 @@
+{
+  "definitions": {
+    "resource4": {
+      "title": "resource4",
+      "properties": {
+        "title": { "type": "string" },
+        "writeOption": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/resource4": {
+      "get": {
+        "tags": ["resource4"],
+        "summary": "List multiple resource4 resources.",
+        "description": "This operation allows you to list and search for resource4 resources provided query arguments.",
+        "operationId": "getresource4s",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/resource4" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["resource4"],
+        "summary": "Create a new resource4",
+        "description": "Create a new resource4",
+        "operationId": "createresource4",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new resource4",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource4" }
+          }
+        ]
+      }
+    },
+    "/test/resource4/{resource4Id}": {
+      "get": {
+        "tags": ["resource4"],
+        "summary": "Return a specific resource4 instance.",
+        "description": "Return a specific resource4 instance.",
+        "operationId": "getresource4",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/resource4" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource4Id",
+            "in": "path",
+            "description": "The ID of the resource4 that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["resource4"],
+        "summary": "Update a specific resource4 instance.",
+        "description": "Update a specific resource4 instance.",
+        "operationId": "updateresource4",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/resource4" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource4Id",
+            "in": "path",
+            "description": "The ID of the resource4 that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update resource4",
+            "required": true,
+            "schema": { "$ref": "#/definitions/resource4" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["resource4"],
+        "summary": "Delete a specific resource4",
+        "description": "Delete a specific resource4",
+        "operationId": "deleteresource4",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "resource4Id",
+            "in": "path",
+            "description": "The ID of the resource4 that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/resource4Swaggerio.json
+++ b/test/snippets/resource4Swaggerio.json
@@ -1,178 +1,334 @@
 {
-  "definitions": {
-    "resource4": {
-      "title": "resource4",
-      "properties": {
-        "title": { "type": "string" },
-        "writeOption": { "type": "string" },
-        "_id": { "type": "string", "description": "ObjectId" }
-      }
-    }
-  },
-  "paths": {
-    "/test/resource4": {
-      "get": {
-        "tags": ["resource4"],
-        "summary": "List multiple resource4 resources.",
-        "description": "This operation allows you to list and search for resource4 resources provided query arguments.",
-        "operationId": "getresource4s",
-        "responses": {
-          "200": {
-            "description": "Resource(s) found.  Returned as array.",
-            "schema": {
-              "type": "array",
-              "items": { "$ref": "#/definitions/resource4" }
-            }
+    "definitions": {
+      "resource4": {
+        "title": "resource4",
+        "properties": {
+          "title": {
+            "type": "string"
           },
-          "401": { "description": "Unauthorized." }
-        },
-        "parameters": [
-          {
-            "name": "skip",
-            "in": "query",
-            "description": "How many records to skip when listing. Used for pagination.",
-            "required": false,
-            "type": "integer",
-            "default": 0
+          "writeOption": {
+            "type": "string"
           },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "How many records to limit the output.",
-            "required": false,
-            "type": "integer",
-            "default": 10
-          },
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Which fields to sort the records on.",
+          "_id": {
             "type": "string",
-            "required": false,
-            "default": ""
-          },
-          {
-            "name": "select",
-            "in": "query",
-            "description": "Select which fields will be returned by the query.",
-            "type": "string",
-            "required": false,
-            "default": ""
-          },
-          {
-            "name": "populate",
-            "in": "query",
-            "description": "Select which fields will be fully populated with the reference.",
-            "type": "string",
-            "required": false,
-            "default": ""
+            "description": "ObjectId"
           }
-        ]
-      },
-      "post": {
-        "tags": ["resource4"],
-        "summary": "Create a new resource4",
-        "description": "Create a new resource4",
-        "operationId": "createresource4",
-        "responses": {
-          "201": { "description": "The resource has been created." },
-          "400": {
-            "description": "An error has occured trying to create the resource."
-          },
-          "401": {
-            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
-          }
-        },
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "Data used to create a new resource4",
-            "required": true,
-            "schema": { "$ref": "#/definitions/resource4" }
-          }
-        ]
+        }
       }
     },
-    "/test/resource4/{resource4Id}": {
-      "get": {
-        "tags": ["resource4"],
-        "summary": "Return a specific resource4 instance.",
-        "description": "Return a specific resource4 instance.",
-        "operationId": "getresource4",
-        "responses": {
-          "200": {
-            "description": "Resource found",
-            "schema": { "$ref": "#/definitions/resource4" }
+    "paths": {
+      "/test/resource4": {
+        "get": {
+          "tags": [
+            "resource4"
+          ],
+          "summary": "List multiple resource4 resources.",
+          "description": "This operation allows you to list and search for resource4 resources provided query arguments.",
+          "operationId": "getresource4s",
+          "responses": {
+            "200": {
+              "description": "Resource(s) found.  Returned as array.",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/resource4"
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized."
+            }
           },
-          "401": { "description": "Unauthorized." },
-          "404": { "description": "Resource not found" },
-          "500": { "description": "An error has occurred." }
+          "parameters": [
+            {
+              "name": "skip",
+              "in": "query",
+              "description": "How many records to skip when listing. Used for pagination.",
+              "required": false,
+              "type": "integer",
+              "default": 0
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "How many records to limit the output.",
+              "required": false,
+              "type": "integer",
+              "default": 10
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "description": "Which fields to sort the records on.",
+              "type": "string",
+              "required": false,
+              "default": ""
+            },
+            {
+              "name": "select",
+              "in": "query",
+              "description": "Select which fields will be returned by the query.",
+              "type": "string",
+              "required": false,
+              "default": ""
+            },
+            {
+              "name": "populate",
+              "in": "query",
+              "description": "Select which fields will be fully populated with the reference.",
+              "type": "string",
+              "required": false,
+              "default": ""
+            }
+          ]
         },
-        "parameters": [
-          {
-            "name": "resource4Id",
-            "in": "path",
-            "description": "The ID of the resource4 that will be retrieved.",
-            "required": true,
-            "type": "string"
-          }
-        ]
+        "post": {
+          "tags": [
+            "resource4"
+          ],
+          "summary": "Create a new resource4",
+          "description": "Create a new resource4",
+          "operationId": "createresource4",
+          "responses": {
+            "201": {
+              "description": "The resource has been created."
+            },
+            "400": {
+              "description": "An error has occured trying to create the resource."
+            },
+            "401": {
+              "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+            }
+          },
+          "parameters": [
+            {
+              "in": "body",
+              "name": "body",
+              "description": "Data used to create a new resource4",
+              "required": true,
+              "schema": {
+                "$ref": "#/definitions/resource4"
+              }
+            }
+          ]
+        }
       },
-      "put": {
-        "tags": ["resource4"],
-        "summary": "Update a specific resource4 instance.",
-        "description": "Update a specific resource4 instance.",
-        "operationId": "updateresource4",
-        "responses": {
-          "200": {
-            "description": "Resource updated",
-            "schema": { "$ref": "#/definitions/resource4" }
+      "/test/resource4/{resource4Id}": {
+        "get": {
+          "tags": [
+            "resource4"
+          ],
+          "summary": "Return a specific resource4 instance.",
+          "description": "Return a specific resource4 instance.",
+          "operationId": "getresource4",
+          "responses": {
+            "200": {
+              "description": "Resource found",
+              "schema": {
+                "$ref": "#/definitions/resource4"
+              }
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
           },
-          "400": { "description": "Resource could not be updated." },
-          "401": { "description": "Unauthorized." },
-          "404": { "description": "Resource not found" },
-          "500": { "description": "An error has occurred." }
+          "parameters": [
+            {
+              "name": "resource4Id",
+              "in": "path",
+              "description": "The ID of the resource4 that will be retrieved.",
+              "required": true,
+              "type": "string"
+            }
+          ]
         },
-        "parameters": [
-          {
-            "name": "resource4Id",
-            "in": "path",
-            "description": "The ID of the resource4 that will be updated.",
-            "required": true,
-            "type": "string"
+        "put": {
+          "tags": [
+            "resource4"
+          ],
+          "summary": "Update a specific resource4 instance.",
+          "description": "Update a specific resource4 instance.",
+          "operationId": "updateresource4",
+          "responses": {
+            "200": {
+              "description": "Resource updated",
+              "schema": {
+                "$ref": "#/definitions/resource4"
+              }
+            },
+            "400": {
+              "description": "Resource could not be updated."
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
           },
-          {
-            "in": "body",
-            "name": "body",
-            "description": "Data used to update resource4",
-            "required": true,
-            "schema": { "$ref": "#/definitions/resource4" }
-          }
-        ]
+          "parameters": [
+            {
+              "name": "resource4Id",
+              "in": "path",
+              "description": "The ID of the resource4 that will be updated.",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "in": "body",
+              "name": "body",
+              "description": "Data used to update resource4",
+              "required": true,
+              "schema": {
+                "$ref": "#/definitions/resource4"
+              }
+            }
+          ]
+        },
+        "delete": {
+          "tags": [
+            "resource4"
+          ],
+          "summary": "Delete a specific resource4",
+          "description": "Delete a specific resource4",
+          "operationId": "deleteresource4",
+          "responses": {
+            "204": {
+              "description": "Resource was deleted"
+            },
+            "400": {
+              "description": "Resource could not be deleted."
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
+          },
+          "parameters": [
+            {
+              "name": "resource4Id",
+              "in": "path",
+              "description": "The ID of the resource4 that will be deleted.",
+              "required": true,
+              "type": "string"
+            }
+          ]
+        }
       },
-      "delete": {
-        "tags": ["resource4"],
-        "summary": "Delete a specific resource4",
-        "description": "Delete a specific resource4",
-        "operationId": "deleteresource4",
-        "responses": {
-          "204": { "description": "Resource was deleted" },
-          "400": { "description": "Resource could not be deleted." },
-          "401": { "description": "Unauthorized." },
-          "404": { "description": "Resource not found" },
-          "500": { "description": "An error has occurred." }
-        },
-        "parameters": [
-          {
-            "name": "resource4Id",
-            "in": "path",
-            "description": "The ID of the resource4 that will be deleted.",
-            "required": true,
-            "type": "string"
+      "/test/resource4/virtual/undefined_query": {
+        "get": {
+          "tags": [
+            "resource4",
+            "virtual"
+          ],
+          "summary": "Virtual resource for resource4 named undefined_query",
+          "description": "get resource4 undefined_query",
+          "operationId": "get resource4 undefined_query",
+          "responses": {
+            "200": {
+              "description": "Resource found"
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
           }
-        ]
+        }
+      },
+      "/test/resource4/virtual/defined": {
+        "get": {
+          "tags": [
+            "resource4",
+            "virtual"
+          ],
+          "summary": "Virtual resource for resource4 named defined",
+          "description": "get resource4 defined",
+          "operationId": "get resource4 defined",
+          "responses": {
+            "200": {
+              "description": "Resource found"
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
+          }
+        }
+      },
+      "/test/resource4/virtual/error": {
+        "get": {
+          "tags": [
+            "resource4",
+            "virtual"
+          ],
+          "summary": "Virtual resource for resource4 named error",
+          "description": "get resource4 error",
+          "operationId": "get resource4 error",
+          "responses": {
+            "200": {
+              "description": "Resource found"
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
+          }
+        }
+      },
+      "/test/resource4/virtual/empty": {
+        "get": {
+          "tags": [
+            "resource4",
+            "virtual"
+          ],
+          "summary": "Virtual resource for resource4 named empty",
+          "description": "get resource4 empty",
+          "operationId": "get resource4 empty",
+          "responses": {
+            "200": {
+              "description": "Resource found"
+            },
+            "401": {
+              "description": "Unauthorized."
+            },
+            "404": {
+              "description": "Resource not found"
+            },
+            "500": {
+              "description": "An error has occurred."
+            }
+          }
+        }
       }
     }
   }
-}
+  

--- a/test/snippets/skipSwaggerio.json
+++ b/test/snippets/skipSwaggerio.json
@@ -1,0 +1,230 @@
+{
+  "definitions": {
+    "skip": {
+      "title": "skip",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "_id": {
+          "type": "string",
+          "description": "ObjectId"
+        }
+      }
+    }
+  },
+  "paths": {
+    "/test/skip": {
+      "get": {
+        "tags": [
+          "skip"
+        ],
+        "summary": "List multiple skip resources.",
+        "description": "This operation allows you to list and search for skip resources provided query arguments.",
+        "operationId": "getskips",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/skip"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "skip"
+        ],
+        "summary": "Create a new skip",
+        "description": "Create a new skip",
+        "operationId": "createskip",
+        "responses": {
+          "201": {
+            "description": "The resource has been created."
+          },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new skip",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/skip"
+            }
+          }
+        ]
+      }
+    },
+    "/test/skip/{skipId}": {
+      "get": {
+        "tags": [
+          "skip"
+        ],
+        "summary": "Return a specific skip instance.",
+        "description": "Return a specific skip instance.",
+        "operationId": "getskip",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": {
+              "$ref": "#/definitions/skip"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "500": {
+            "description": "An error has occurred."
+          }
+        },
+        "parameters": [
+          {
+            "name": "skipId",
+            "in": "path",
+            "description": "The ID of the skip that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "skip"
+        ],
+        "summary": "Update a specific skip instance.",
+        "description": "Update a specific skip instance.",
+        "operationId": "updateskip",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": {
+              "$ref": "#/definitions/skip"
+            }
+          },
+          "400": {
+            "description": "Resource could not be updated."
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "500": {
+            "description": "An error has occurred."
+          }
+        },
+        "parameters": [
+          {
+            "name": "skipId",
+            "in": "path",
+            "description": "The ID of the skip that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update skip",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/skip"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "skip"
+        ],
+        "summary": "Delete a specific skip",
+        "description": "Delete a specific skip",
+        "operationId": "deleteskip",
+        "responses": {
+          "204": {
+            "description": "Resource was deleted"
+          },
+          "400": {
+            "description": "Resource could not be deleted."
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "500": {
+            "description": "An error has occurred."
+          }
+        },
+        "parameters": [
+          {
+            "name": "skipId",
+            "in": "path",
+            "description": "The ID of the skip that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/snippets/skipSwaggerio.json
+++ b/test/snippets/skipSwaggerio.json
@@ -225,6 +225,31 @@
           }
         ]
       }
+    },
+    "/test/skip/virtual/resource": {
+      "get": {
+        "tags": [
+          "skip",
+          "virtual"
+        ],
+        "summary": "Virtual resource for skip named resource",
+        "description": "get skip resource",
+        "operationId": "get skip resource",
+        "responses": {
+          "200": {
+            "description": "Resource found"
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "404": {
+            "description": "Resource not found"
+          },
+          "500": {
+            "description": "An error has occurred."
+          }
+        }
+      }
     }
   }
 }

--- a/test/snippets/testSwaggerio.json
+++ b/test/snippets/testSwaggerio.json
@@ -1,0 +1,177 @@
+{
+  "definitions": {
+    "ref": {
+      "title": "ref",
+      "properties": {
+        "data": { "type": "string" },
+        "_id": { "type": "string", "description": "ObjectId" }
+      }
+    }
+  },
+  "paths": {
+    "/test/ref": {
+      "get": {
+        "tags": ["ref"],
+        "summary": "List multiple ref resources.",
+        "description": "This operation allows you to list and search for ref resources provided query arguments.",
+        "operationId": "getrefs",
+        "responses": {
+          "200": {
+            "description": "Resource(s) found.  Returned as array.",
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/ref" }
+            }
+          },
+          "401": { "description": "Unauthorized." }
+        },
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "How many records to skip when listing. Used for pagination.",
+            "required": false,
+            "type": "integer",
+            "default": 0
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many records to limit the output.",
+            "required": false,
+            "type": "integer",
+            "default": 10
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Which fields to sort the records on.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "description": "Select which fields will be returned by the query.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          },
+          {
+            "name": "populate",
+            "in": "query",
+            "description": "Select which fields will be fully populated with the reference.",
+            "type": "string",
+            "required": false,
+            "default": ""
+          }
+        ]
+      },
+      "post": {
+        "tags": ["ref"],
+        "summary": "Create a new ref",
+        "description": "Create a new ref",
+        "operationId": "createref",
+        "responses": {
+          "201": { "description": "The resource has been created." },
+          "400": {
+            "description": "An error has occured trying to create the resource."
+          },
+          "401": {
+            "description": "Unauthorized.  Note that anonymous submissions are *enabled* by default."
+          }
+        },
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to create a new ref",
+            "required": true,
+            "schema": { "$ref": "#/definitions/ref" }
+          }
+        ]
+      }
+    },
+    "/test/ref/{refId}": {
+      "get": {
+        "tags": ["ref"],
+        "summary": "Return a specific ref instance.",
+        "description": "Return a specific ref instance.",
+        "operationId": "getref",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "schema": { "$ref": "#/definitions/ref" }
+          },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "refId",
+            "in": "path",
+            "description": "The ID of the ref that will be retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["ref"],
+        "summary": "Update a specific ref instance.",
+        "description": "Update a specific ref instance.",
+        "operationId": "updateref",
+        "responses": {
+          "200": {
+            "description": "Resource updated",
+            "schema": { "$ref": "#/definitions/ref" }
+          },
+          "400": { "description": "Resource could not be updated." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "refId",
+            "in": "path",
+            "description": "The ID of the ref that will be updated.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Data used to update ref",
+            "required": true,
+            "schema": { "$ref": "#/definitions/ref" }
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["ref"],
+        "summary": "Delete a specific ref",
+        "description": "Delete a specific ref",
+        "operationId": "deleteref",
+        "responses": {
+          "204": { "description": "Resource was deleted" },
+          "400": { "description": "Resource could not be deleted." },
+          "401": { "description": "Unauthorized." },
+          "404": { "description": "Resource not found" },
+          "500": { "description": "An error has occurred." }
+        },
+        "parameters": [
+          {
+            "name": "refId",
+            "in": "path",
+            "description": "The ID of the ref that will be deleted.",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -90,12 +90,14 @@ function wasInvoked(entity, sequence, method) {
 
 describe('Connect to MongoDB', () => {
   it('Connect to MongoDB', () => mongoose.connect('mongodb://localhost:27017/test', {
+    useUnifiedTopology: true,
     useNewUrlParser: true,
   }));
 
   it('Drop test database', () => mongoose.connection.db.dropDatabase());
 
   it('Should connect MongoDB without mongoose', () => MongoClient.connect('mongodb://localhost:27017', {
+    useUnifiedTopology: true,
     useNewUrlParser: true,
   })
     .then((client) => db = client.db('test')));

--- a/test/test.js
+++ b/test/test.js
@@ -1802,7 +1802,30 @@ describe('Handle native data formats', () => {
       assert.equal(response[0].updated, null);
     }));
 
-  it('Should find the boolean values based on equality', () => request(app)
+  it('Should still find the null values based on string if explicitely provided "null"', () => request(app)
+  .get('/test/resource2?title__eq="null"')
+    .send()
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      const response = res.body;
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+    }));
+
+  it('Should find the boolean false values based on equality', () => request(app)
+    .get('/test/resource2?description__eq=false')
+    .send()
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      const response = res.body;
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].married, true);
+    }));
+
+  it('Should find the boolean true values based on equality', () => request(app)
     .get('/test/resource2?married__eq=true')
     .send()
     .expect('Content-Type', /json/)
@@ -1816,6 +1839,18 @@ describe('Handle native data formats', () => {
 
   it('Should still find the boolean values based on string if explicitely provided', () => request(app)
     .get('/test/resource2?description__eq=%22false%22')
+    .send()
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      const response = res.body;
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].married, true);
+    }));
+
+  it('Should still find the boolean values based on string if explicitely provided', () => request(app)
+    .get('/test/resource2?married__eq=%22true%22')
     .send()
     .expect('Content-Type', /json/)
     .expect(200)

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-prototype-builtins */
 'use strict';
 
 const express = require('express');
@@ -172,11 +173,11 @@ describe('Build Resources for following tests', () => {
       },
       married: {
         type: Boolean,
-        default: false
+        default: false,
       },
       updated: {
         type: Number,
-        default: null
+        default: null,
       },
       description: {
         type: String,
@@ -621,6 +622,7 @@ describe('Test single resource CRUD capabilities', () => {
 let refDoc1Content = null;
 let refDoc1Response = null;
 const resourceNames = [];
+// eslint-disable-next-line max-statements
 function testSearch(testPath) {
   it('Should populate', () => request(app)
     .get(`${testPath}?name=noage&populate=list.data`)
@@ -1428,7 +1430,7 @@ describe('Handle native data formats', () => {
     .send({
       title: 'null',
       description: 'false',
-      married: true
+      married: true,
     })
     .expect('Content-Type', /json/)
     .expect(201)
@@ -1446,8 +1448,8 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
     }));
 
   it('Should find the record when filtering the description as "false"', () => request(app)
@@ -1457,9 +1459,9 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
-      assert.equal(res.body[0].description, 'false');
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].description, 'false');
     }));
 
   it('Should find the record when filtering the description as "true"', () => request(app)
@@ -1469,7 +1471,7 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 0);
+      assert.equal(response.length, 0);
     }));
 
   it('Should find the record when filtering the updated property as null with strict equality', () => request(app)
@@ -1479,9 +1481,9 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
-      assert.equal(res.body[0].updated, null);
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].updated, null);
     }));
 
   it('Should find the boolean values based on equality', () => request(app)
@@ -1491,9 +1493,9 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
-      assert.equal(res.body[0].married, true);
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].married, true);
     }));
 
   it('Should still find the boolean values based on string if explicitely provided', () => request(app)
@@ -1503,9 +1505,9 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
-      assert.equal(res.body[0].married, true);
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].married, true);
     }));
 
   it('Should CAST a boolean to find the boolean values based on equals', () => request(app)
@@ -1515,9 +1517,9 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 1);
-      assert.equal(res.body[0].title, 'null');
-      assert.equal(res.body[0].married, true);
+      assert.equal(response.length, 1);
+      assert.equal(response[0].title, 'null');
+      assert.equal(response[0].married, true);
     }));
 
   it('Should CAST a boolean to find the boolean values based on equals', () => request(app)
@@ -1527,7 +1529,7 @@ describe('Handle native data formats', () => {
     .expect(200)
     .then((res) => {
       const response = res.body;
-      assert.equal(res.body.length, 0);
+      assert.equal(response.length, 0);
     }));
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -423,6 +423,105 @@ describe('Test single resource CRUD capabilities', () => {
       resource = res.body;
     }));
 
+  it('/PATCH Reject update due to incorrect patch operation', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'does-not-exist', 'path': '/title', 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_OP_INVALID');
+    }));
+
+  it('/PATCH Should not care whether patch is array or not', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send({ 'op': 'test', 'path': '/title', 'value': 'Test3' })
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      assert.equal(res.body.title, 'Test3');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch object', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send(['invalid-patch'])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_NOT_AN_OBJECT');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch value', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'replace', 'path': '/title', 'value': undefined }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_VALUE_REQUIRED');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch add path', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'add', 'path': '/path/does/not/exist', 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_PATH_CANNOT_ADD');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch path', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'replace', 'path': '/path/does/not/exist', 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_PATH_UNRESOLVABLE');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch path', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'replace', 'path': 1, 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_PATH_INVALID');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch path', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'add', 'path': '/path/does/not/exist', 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_PATH_CANNOT_ADD');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch path', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'move', 'from': '/path/does/not/exist', 'path': '/path/does/not/exist', 'value': 'Test4' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_FROM_UNRESOLVABLE');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch array', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'add', 'path': '/list/invalidindex', 'value': '2' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_PATH_ILLEGAL_ARRAY_INDEX');
+    }));
+
+  it('/PATCH Reject update due to incorrect patch array', () => request(app)
+    .patch(`/test/resource1/${resource._id}`)
+    .send([{ 'op': 'add', 'path': '/list/9999', 'value': '2' }])
+    .expect('Content-Type', /json/)
+    .expect(400)
+    .then((res) => {
+      assert.equal(res.body.errors[0].name, 'OPERATION_VALUE_OUT_OF_BOUNDS');
+    }));
+
   it('/GET The changed resource', () => request(app)
     .get(`/test/resource1/${resource._id}`)
     .expect('Content-Type', /json/)

--- a/test/test.js
+++ b/test/test.js
@@ -346,6 +346,111 @@ describe('Build Resources for following tests', () => {
       },
     });
   });
+
+  it('Build the /test/skip endpoints', () => {
+    // Create the schema.
+    const SkipSchema = new mongoose.Schema({
+      title: String,
+     });
+
+    // Create the model.
+    const SkipModel = mongoose.model('skip', SkipSchema);
+
+    // Create the REST resource and continue.
+    Resource(app, '/test', 'skip', SkipModel)
+      .rest({
+        before(req, res, next) {
+          req.skipResource = true;
+          next();
+        },
+      })
+      .virtual({
+        path: 'resource',
+        before: function(req, res, next) {
+          req.skipResource = true;
+          return next();
+        },
+      });
+  });
+
+describe('Test skipResource', () => {
+  const resource = {};
+  it('/GET empty list', () => request(app)
+    .get('/test/skip')
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = 'Cannot GET /test/skip';
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/POST Create new resource', () => request(app)
+    .post('/test/skip')
+    .send({
+      title: 'Test1',
+      description: '12345678',
+    })
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = 'Cannot POST /test/skip';
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/GET The new resource', () => request(app)
+    .get(`/test/skip/${resource._id}`)
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = `Cannot GET /test/skip/${resource._id}`;
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/PUT Change data on the resource', () => request(app)
+    .put(`/test/skip/${resource._id}`)
+    .send({
+      title: 'Test2',
+    })
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = `Cannot PUT /test/skip/${resource._id}`;
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/PATCH Change data on the resource', () => request(app)
+    .patch(`/test/skip/${resource._id}`)
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = `Cannot PATCH /test/skip/${resource._id}`;
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/DELETE the resource', () => request(app)
+    .delete(`/test/skip/${resource._id}`)
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = `Cannot DELETE /test/skip/${resource._id}`;
+      assert(response.includes(expected), 'Response not found.');
+    }));
+
+  it('/VIRTUAL the resource', () => request(app)
+    .get('/test/skip/virtual/resource')
+    .expect('Content-Type', /text\/html/)
+    .expect(404)
+    .then((res) => {
+      const response = res.text;
+      const expected = 'Cannot GET /test/skip/virtual/resource';
+      assert(response.includes(expected), 'Response not found.');
+    }));
 });
 
 describe('Test single resource CRUD capabilities', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -114,7 +114,15 @@ describe('Build Resources for following tests', () => {
     const RefModel = mongoose.model('ref', RefSchema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test', 'ref', RefModel).rest();
+    const test = Resource(app, '/test', 'ref', RefModel).rest();
+    const testSwaggerio = require('./snippets/testSwaggerio.json');
+    const swaggerio = test.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.ref);
+    assert.equal(swaggerio.definitions.ref.title, 'ref');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, testSwaggerio);
   });
 
   it('Build the /test/resource1 endpoints', () => {
@@ -151,7 +159,7 @@ describe('Build Resources for following tests', () => {
     const Resource1Model = mongoose.model('resource1', Resource1Schema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test', 'resource1', Resource1Model).rest({
+    const resource1 = Resource(app, '/test', 'resource1', Resource1Model).rest({
       afterDelete(req, res, next) {
         // Check that the delete item is still being returned via resourcejs.
         assert.notEqual(res.resource.item, {});
@@ -161,6 +169,14 @@ describe('Build Resources for following tests', () => {
         next();
       },
     });
+    const resource1Swaggerio = require('./snippets/resource1Swaggerio.json');
+    const swaggerio = resource1.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.resource1);
+    assert.equal(swaggerio.definitions.resource1.title, 'resource1');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, resource1Swaggerio);
   });
 
   it('Build the /test/resource2 endpoints', () => {
@@ -190,7 +206,7 @@ describe('Build Resources for following tests', () => {
     const Resource2Model = mongoose.model('resource2', Resource2Schema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test', 'resource2', Resource2Model).rest({
+    const resource2 = Resource(app, '/test', 'resource2', Resource2Model).rest({
       // Register before/after global handlers.
       before(req, res, next) {
         // Store the invoked handler and continue.
@@ -213,6 +229,14 @@ describe('Build Resources for following tests', () => {
         next();
       },
     });
+    const resource2Swaggerio = require('./snippets/resource2Swaggerio.json');
+    const swaggerio = resource2.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.resource2);
+    assert.equal(swaggerio.definitions.resource2.title, 'resource2');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, resource2Swaggerio);
   });
 
   it('Build the /test/date endpoints and fill it with data', () => {
@@ -225,7 +249,15 @@ describe('Build Resources for following tests', () => {
     // Create the model.
     const Model = mongoose.model('date', Schema);
 
-    Resource(app, '/test', 'date', Model).rest();
+    const date = Resource(app, '/test', 'date', Model).rest();
+    const resource3Swaggerio = require('./snippets/dateSwaggerio.json');
+    const swaggerio = date.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.date);
+    assert.equal(swaggerio.definitions.date.title, 'date');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, resource3Swaggerio);
     return Promise.all(testDates.map((date) => request(app)
       .post('/test/date')
       .send({
@@ -258,13 +290,21 @@ describe('Build Resources for following tests', () => {
     const Nested1Model = mongoose.model('nested1', Nested1Schema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test/resource1/:resource1Id', 'nested1', Nested1Model).rest({
+    const nested1 = Resource(app, '/test/resource1/:resource1Id', 'nested1', Nested1Model).rest({
       // Register before global handlers to set the resource1 variable.
       before(req, res, next) {
         req.body.resource1 = req.params.resource1Id;
         next();
       },
     });
+    const nested1Swaggerio = require('./snippets/nested1Swaggerio.json');
+    const swaggerio = nested1.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.nested1);
+    assert.equal(swaggerio.definitions.nested1.title, 'nested1');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, nested1Swaggerio);
   });
 
   it('Build the /test/resource2/:resource2Id/nested2 endpoints', () => {
@@ -292,7 +332,7 @@ describe('Build Resources for following tests', () => {
     const Nested2Model = mongoose.model('nested2', Nested2Schema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test/resource2/:resource2Id', 'nested2', Nested2Model).rest({
+    const nested2 = Resource(app, '/test/resource2/:resource2Id', 'nested2', Nested2Model).rest({
       // Register before/after global handlers.
       before(req, res, next) {
         req.body.resource2 = req.params.resource2Id;
@@ -308,6 +348,14 @@ describe('Build Resources for following tests', () => {
         next();
       },
     });
+    const nested2Swaggerio = require('./snippets/nested2Swaggerio.json');
+    const swaggerio = nested2.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.nested2);
+    assert.equal(swaggerio.definitions.nested2.title, 'nested2');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, nested2Swaggerio);
   });
 
   it('Build the /test/resource3 endpoints', () => {
@@ -337,7 +385,7 @@ describe('Build Resources for following tests', () => {
     const Resource3Model = mongoose.model('resource3', Resource3Schema);
 
     // Create the REST resource and continue.
-    Resource(app, '/test', 'resource3', Resource3Model).rest({
+    const resource3 = Resource(app, '/test', 'resource3', Resource3Model).rest({
       before(req, res, next) {
         // This setting should be passed down to the underlying `save()` command
         req.writeOptions = { writeSetting: true };
@@ -345,33 +393,15 @@ describe('Build Resources for following tests', () => {
         next();
       },
     });
-  });
-
-  it('Build the /test/skip endpoints', () => {
-    // Create the schema.
-    const SkipSchema = new mongoose.Schema({
-      title: String,
+    const resource3Swaggerio = require('./snippets/resource3Swaggerio.json');
+    const swaggerio = resource3.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.resource3);
+    assert.equal(swaggerio.definitions.resource3.title, 'resource3');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, resource3Swaggerio);
      });
-
-    // Create the model.
-    const SkipModel = mongoose.model('skip', SkipSchema);
-
-    // Create the REST resource and continue.
-    Resource(app, '/test', 'skip', SkipModel)
-      .rest({
-        before(req, res, next) {
-          req.skipResource = true;
-          next();
-        },
-      })
-      .virtual({
-        path: 'resource',
-        before: function(req, res, next) {
-          req.skipResource = true;
-          return next();
-        },
-      });
-  });
 
   it('Build the /test/resource4 endpoints', () => {
     // Create the schema.
@@ -387,7 +417,7 @@ describe('Build Resources for following tests', () => {
     doc.save();
 
     // Create the REST resource and continue.
-    Resource(app, '/test', 'resource4', Resource4Model)
+    const resource4 = Resource(app, '/test', 'resource4', Resource4Model)
     .rest({
       beforePatch(req, res, next) {
         req.modelQuery = { findOne: function findOne(_,callback) {
@@ -433,6 +463,48 @@ describe('Build Resources for following tests', () => {
         return next();
       },
     });
+    const resource4Swaggerio = require('./snippets/resource4Swaggerio.json');
+    const swaggerio = resource4.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.resource4);
+    assert.equal(swaggerio.definitions.resource4.title, 'resource4');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, resource4Swaggerio);
+  });
+
+  it('Build the /test/skip endpoints', () => {
+    // Create the schema.
+    const SkipSchema = new mongoose.Schema({
+      title: String,
+     });
+
+    // Create the model.
+    const SkipModel = mongoose.model('skip', SkipSchema);
+
+    // Create the REST resource and continue.
+    const skipResource = Resource(app, '/test', 'skip', SkipModel)
+      .rest({
+        before(req, res, next) {
+          req.skipResource = true;
+          next();
+        },
+      })
+      .virtual({
+        path: 'resource',
+        before: function(req, res, next) {
+          req.skipResource = true;
+          return next();
+        },
+      });
+    const skipSwaggerio = require('./snippets/skipSwaggerio.json');
+    const swaggerio = skipResource.swagger();
+    assert.equal(Object.values(swaggerio).length,2);
+    assert.ok(swaggerio.definitions);
+    assert.ok(swaggerio.definitions.skip);
+    assert.equal(swaggerio.definitions.skip.title, 'skip');
+    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.deepEqual(swaggerio, skipSwaggerio);
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,7 @@ function wasInvoked(entity, sequence, method) {
 
 describe('Connect to MongoDB', () => {
   it('Connect to MongoDB', () => mongoose.connect('mongodb://localhost:27017/test', {
+    useCreateIndex: true,
     useUnifiedTopology: true,
     useNewUrlParser: true,
   }));
@@ -97,6 +98,7 @@ describe('Connect to MongoDB', () => {
   it('Drop test database', () => mongoose.connection.db.dropDatabase());
 
   it('Should connect MongoDB without mongoose', () => MongoClient.connect('mongodb://localhost:27017', {
+    useCreateIndex: true,
     useUnifiedTopology: true,
     useNewUrlParser: true,
   })
@@ -401,7 +403,7 @@ describe('Build Resources for following tests', () => {
     assert.equal(swaggerio.definitions.resource3.title, 'resource3');
     assert.equal(Object.values(swaggerio.paths).length, 2);
     assert.deepEqual(swaggerio, resource3Swaggerio);
-     });
+  });
 
   it('Build the /test/resource4 endpoints', () => {
     // Create the schema.
@@ -2610,4 +2612,8 @@ describe('Test before hooks', () => {
         assert.equal(calls[1], 'after');
       }));
   });
+});
+
+describe('Test Swagger.io', () => {
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -471,7 +471,7 @@ describe('Build Resources for following tests', () => {
     assert.ok(swaggerio.definitions);
     assert.ok(swaggerio.definitions.resource4);
     assert.equal(swaggerio.definitions.resource4.title, 'resource4');
-    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.equal(Object.values(swaggerio.paths).length, 6);
     assert.deepEqual(swaggerio, resource4Swaggerio);
   });
 
@@ -505,7 +505,7 @@ describe('Build Resources for following tests', () => {
     assert.ok(swaggerio.definitions);
     assert.ok(swaggerio.definitions.skip);
     assert.equal(swaggerio.definitions.skip.title, 'skip');
-    assert.equal(Object.values(swaggerio.paths).length, 2);
+    assert.equal(Object.values(swaggerio.paths).length, 3);
     assert.deepEqual(swaggerio, skipSwaggerio);
   });
 });

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,25 @@
+
+const zipObject = (props, values) => props.reduce((prev, prop, i) => Object.assign(prev, { [prop]: values[i] }), {});
+
+const isObjectLike = (obj) => obj !== null && typeof obj === 'object';
+
+const get = (obj, path, defaultValue) => path.split('.').reduce((a, c) => (a && a[c] ? a[c] : (defaultValue || null)), obj);
+
+const set = (obj, path, value) => {
+    if (Object(obj) !== obj) return obj;
+    // If not yet an array, get the keys from the string-path
+    if (!Array.isArray(path)) path = path.toString().match(/[^.[\]]+/g) || [];
+    // Split the path. Note: last index is the value key
+    path.slice(0,-1).reduce((a, c, i) =>
+         Object(a[c]) === a[c] // Does the key exist and is its value an object?
+             // Yes: then follow that path
+             ? a[c]
+             // No: create the key. Is the next key a potential array-index?
+             : a[c] = Math.abs(path[i+1])>>0 === +path[i+1]
+                   ? [] // Yes: assign a new array object
+                   : {}, // No: assign a new plain object
+         obj)[path[path.length-1]] = value; // Finally assign the value to the last key
+    return obj;
+};
+
+module.exports = { zipObject, isObjectLike, get, set };


### PR DESCRIPTION
Release Candidate (Updated):
- Coveralls support
- Some fixes to testing
- Some eslint errors resolved
- Improve Travis configuration (mongo setup, addition and removal of node versions)
- Dependancy updates
- Switch composable-middleware to native ExpessJS (NEW)
- skipResource tests, some error and empty query error tests, patch tests (NEW)
- Tests for Virtual (NEW)
- Tests that virtual paths are NOT defined when there is no virtual resources available (NEW, Done via Swagger)
- Removal of lodash in favor of ES6

Possible:
- Add test for untested [parts](https://coveralls.io/github/Sefriol/resourcejs) (~~skipResource~~, ~~incorrect patch~~, writeOptions error, convertIds, index query error)