### PR TITLE
High performance optimization during aggregation

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -514,7 +514,7 @@ class Resource {
         }
 
         // Add limit and skip to aggregation pipeline if present
-        if ( query.pipeline.length > 0 ) {
+        if ( query.pipeline && query.pipeline.length > 0 ) {
           query.pipeline.unshift({ $limit: reqQuery.limit });
           query.pipeline.unshift({ $skip: reqQuery.skip });
           reqQuery.skip = 0; // reset skip

--- a/Resource.js
+++ b/Resource.js
@@ -513,6 +513,13 @@ class Resource {
           reqQuery.skip = pageRange.skip;
         }
 
+        // Add limit and skip to aggregation pipeline if present
+        if ( query.pipeline.length > 0 ) {
+          query.pipeline.unshift({ $limit: reqQuery.limit });
+          query.pipeline.unshift({ $skip: reqQuery.skip });
+          reqQuery.skip = 0; // reset skip
+        }
+
         // Next get the items within the index.
         const queryExec = query
           .find(findQuery)

--- a/Resource.js
+++ b/Resource.js
@@ -477,7 +477,7 @@ class Resource {
       const query = req.modelQuery || req.model || this.model;
 
       // First get the total count.
-      this.countQuery(countQuery.find(findQuery), query.pipeline).countDocuments((err, count) => {
+      this.countQuery(countQuery.find(findQuery), countQuery.pipeline).countDocuments((err, count) => {
         if (err) {
           debug.index(err);
           return Resource.setResponse(res, { status: 400, error: err }, next);


### PR DESCRIPTION
Optimization is mainly for query with lookup aggregations without some specific match condition, contains only limit & skip options.

1) Count query does not respect aggregation pipeline for count query. In some cases we are facing large  number of mongo index usage for unnecessary aggregation.

2) Adding limit & skip into the first place in aggregation pipeline if present. Reason is the same - large number of mongo index usage.

No impact for interface.