### PR TITLE
slight improvement to error handler

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -125,8 +125,9 @@ class Resource {
     // Add a fallback error handler.
     const error = (err, req, res, next) => {
       if (err) {
-        res.status(400).json({
-          status: 400,
+        const status = err.status ? err.status : 400;
+        res.status(status).json({
+          status,
           message: err.message || err,
         });
       }


### PR DESCRIPTION
Calling `next(err)` in Express versions >= 4.x will pass the error object to the closest error-handling middleware (simply by checking the argument length of the middleware callback). This means that any errors passed to `next` by applications that utilize Resource.js will encounter [the fallback error handler exposed by the library](https://github.com/travist/resourcejs/blob/74826ea06db7982dfbd6ef9c35b92dff00b52de4/Resource.js#L126), which may circumvent any subsequent error handling middleware that the wrapping Express application may require or desire. While I would argue that any Express application wrapping Resource.js should be responsible for its own error handling (relieving Resource.js of the responsibility), this PR aims to make Resource.js' error handling a little more flexible by allowing variable response statuses.