### PR TITLE
Feat/support or query string operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,22 +411,23 @@ Filtering the results.
 --------------------------------
 The ```index()``` that is created is capable of doing some complex filtering using Query arguments within the URL. They are described as the following.
 
-| Filter                       | Query    | Example                                              | Description                                                      |
-|------------------------------|----------|------------------------------------------------------|------------------------------------------------------------------|
-| **equal**                    | `equals` | `/users?gender=male` 			                     | both return all male users                                       |
-| **not equal**                | `ne`     | `/users?gender__ne=male`                             | returns all users who are not male (`female` and `x`)            |
-| **greater than**             | `gt`     | `/users?age__gt=18`                                  | returns all users older than 18                                  |
-| **greater than or equal to** | `gte`    | `/users?age__gte=18`                                 | returns all users 18 and older (age should be a number property) |
-| **less than**                | `lt`     | `/users?age__lt=30`                                  | returns all users age 29 and younger                             |
-| **less than or equal to**    | `lte`    | `/users?age__lte=30`                                 | returns all users age 30 and younger                             |
-| **in**                       | `in`     | `/users?gender__in=female,male`                      | returns all female and male users                                |
-| **nin**                      | `nin`    | `/users?age__nin=18,21`                              | returns all users who are not 18 or 21                           |
-| **exists=true**              | `exists` | `/users?age__exists=true`                            | returns all users where the age is provided.                     |
-| **exists=false**             | `exists` | `/users?age__exists=false`                           | returns all users where the age is not provided.                 |
-| **Regex**                    | `regex`  | `/users?username__regex=/^travis/i`                  | returns all users with a username starting with travis           |
-| **limit**                    | `limit` | `/users?limit=5`                                     | limits results to the specified amount
-| **skip**                     | `skip` | `/users?skip=10`                                     | skip to the specified record in the result set
-| **select**                   | `select` | `/users?select=first_name,last_name`               | return only the specified fields
+| Filter                       | Query    | Example                                                      | Description                                                      |
+|------------------------------|----------|--------------------------------------------------------------|------------------------------------------------------------------|
+| **equal**                    | `equals` | `/users?gender=male` 			                                     | both return all male users                                       |
+| **not equal**                | `ne`     | `/users?gender__ne=male`                                     | returns all users who are not male (`female` and `x`)            |
+| **greater than**             | `gt`     | `/users?age__gt=18`                                          | returns all users older than 18                                  |
+| **greater than or equal to** | `gte`    | `/users?age__gte=18`                                         | returns all users 18 and older (age should be a number property) |
+| **less than**                | `lt`     | `/users?age__lt=30`                                          | returns all users age 29 and younger                             |
+| **less than or equal to**    | `lte`    | `/users?age__lte=30`                                         | returns all users age 30 and younger                             |
+| **in**                       | `in`     | `/users?gender__in=female,male`                              | returns all female and male users                                |
+| **nin**                      | `nin`    | `/users?age__nin=18,21`                                      | returns all users who are not 18 or 21                           |
+| **exists=true**              | `exists` | `/users?age__exists=true`                                    | returns all users where the age is provided.                     |
+| **exists=false**             | `exists` | `/users?age__exists=false`                                   | returns all users where the age is not provided.                 |
+| **Regex**                    | `regex`  | `/users?username__regex=/^travis/i`                          | returns all users with a username starting with travis           |
+| **or**                       | `or`     | `/users?__or=first_name__regex=/^travis/i,age__gt=18` | return all users with a username starting with travis OR older than 18
+| **limit**                    | `limit`  | `/users?limit=5`                                             | limits results to the specified amount
+| **skip**                     | `skip`   | `/users?skip=10`                                             | skip to the specified record in the result set
+| **select**                   | `select` | `/users?select=first_name,last_name`                         | return only the specified fields
 
 Adding Swagger.io v2 documentation
 --------------------------------

--- a/Resource.js
+++ b/Resource.js
@@ -450,8 +450,7 @@ class Resource {
       }
     };
 
-    // Iterate through each filter.
-    Object.entries(filters).forEach(([name, value]) => {
+    const processSingleFilter = (name, value)=> {
       // Get the filter object.
       const filter = utils.zipObject(['name', 'selector'], name.split('__'));
 
@@ -471,7 +470,7 @@ class Resource {
             regex = null;
           }
           if (regex) {
-            setFindQuery(filter.name, regex);
+            return [filter.name, regex];
           }
           return;
         } // See if there is a selector.
@@ -498,20 +497,44 @@ class Resource {
           }
 
           filterQuery[`$${filter.selector}`] = value;
-          setFindQuery(filter.name, filterQuery);
-          return;
+          return [filter.name, filterQuery];
         }
         else {
           // Set the find query to this value.
           value = Resource.getQueryValue(filter.name, value, param, options, filter.selector);
-          setFindQuery(filter.name, value);
-          return;
+          return [filter.name, value];
         }
       }
 
       if (!options.queryFilter) {
         // Set the find query to this value.
-        setFindQuery(filter.name, value);
+        return [filter.name, value];
+      }
+    }
+
+    // Iterate through each filter.
+    Object.entries(filters).forEach(([name, value]) => {
+      let filter;
+      // Process each statement of 'or' operator separately
+      if (name === '__or') {
+        const isParsed = Array.isArray(value);
+        const statements = !isParsed ? value.split(',') : value;
+        const filters = statements.map((statement) => {
+          const [statementName, statementValue] = !isParsed ? statement.split('=') : Object.entries(statement)[0];
+          const filter = processSingleFilter(statementName, statementValue);
+          if (filter.length) {
+            const [n, v] = filter;
+            return { [n]: v };
+          }
+          return null;
+        }).filter(item => !!item);
+        filter = ['$or', filters];
+      }
+      else {
+        filter = processSingleFilter(name, value);
+      }
+      if (filter?.length) {
+        setFindQuery(...filter);
       }
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,19 @@ const testDates = [
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
+app.use((err, req, res, next) => {
+  // delegate to the default Express error handler when the headers have already been sent to the client
+  if (res.headersSent) {
+    return next(err);
+  }
+  console.log('Uncaught exception:');
+  if (err) {
+    console.log(err);
+    console.log(err.stack);
+  }
+  res.status(err.status ? err.status : 400).send(typeof err === 'string' ? {message: err} : err);
+});
+
 // An object to store handler events.
 let handlers = {};
 
@@ -2313,8 +2326,8 @@ describe('Test nested resource handlers capabilities', () => {
   it('A GET (Index) request to a child resource should invoke the global handlers', (done) => {
     request(app)
       .get(`/test/resource2/${resource._id}/nested2`)
-      // .expect('Content-Type', /json/)
-      // .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(200)
       .then((res) => {
         const response = res.body;
         assert.equal(response.length, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -1504,6 +1504,23 @@ function testSearch(testPath) {
           });
       });
   });
+
+  it('or search selector', () => request(app)
+    .get(`${testPath}?__or=age__eq=5,title__eq=No Age`)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((res) => {
+      const response = res.body;
+      assert.equal(response.length, 2);
+      response.forEach((resource) => {
+        if (typeof resource.age === 'number') {
+          assert.equal(resource.age, 5);
+        }
+        else {
+          assert.equal(resource.title, 'No Age');
+        }
+      });
+    }));
 }
 
 describe('Test single resource search capabilities', () => {
@@ -2293,24 +2310,27 @@ describe('Test nested resource handlers capabilities', () => {
       nested = response;
     }));
 
-  it('A GET (Index) request to a child resource should invoke the global handlers', () => request(app)
-    .get(`/test/resource2/${resource._id}/nested2`)
-    .expect('Content-Type', /json/)
-    .expect(200)
-    .then((res) => {
-      const response = res.body;
-      assert.equal(response.length, 1);
-      assert.equal(response[0].title, nested.title);
-      assert.equal(response[0].description, nested.description);
-      assert(response[0].hasOwnProperty('resource2'), 'The response must contain the parent object `_id`');
-      assert.equal(response[0].resource2, resource._id);
-      assert(response[0].hasOwnProperty('_id'), 'The response must contain the mongo object `_id`');
-      assert.equal(response[0]._id, nested._id);
+  it('A GET (Index) request to a child resource should invoke the global handlers', (done) => {
+    request(app)
+      .get(`/test/resource2/${resource._id}/nested2`)
+      // .expect('Content-Type', /json/)
+      // .expect(200)
+      .then((res) => {
+        const response = res.body;
+        assert.equal(response.length, 1);
+        assert.equal(response[0].title, nested.title);
+        assert.equal(response[0].description, nested.description);
+        assert(response[0].hasOwnProperty('resource2'), 'The response must contain the parent object `_id`');
+        assert.equal(response[0].resource2, resource._id);
+        assert(response[0].hasOwnProperty('_id'), 'The response must contain the mongo object `_id`');
+        assert.equal(response[0]._id, nested._id);
 
-      // Confirm that the handlers were called.
-      assert.equal(wasInvoked('nested2', 'before', 'index'), true);
-      assert.equal(wasInvoked('nested2', 'after', 'index'), true);
-    }));
+        // Confirm that the handlers were called.
+        assert.equal(wasInvoked('nested2', 'before', 'index'), true);
+        assert.equal(wasInvoked('nested2', 'after', 'index'), true);
+        done();
+      }).catch(done)
+  });
 
   it('A DELETE request to a child resource should invoke the global handlers', () => request(app)
     .delete(`/test/resource2/${resource._id}/nested2/${nested._id}`)

--- a/test/test.js
+++ b/test/test.js
@@ -26,19 +26,6 @@ const testDates = [
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
-app.use((err, req, res, next) => {
-  // delegate to the default Express error handler when the headers have already been sent to the client
-  if (res.headersSent) {
-    return next(err);
-  }
-  console.log('Uncaught exception:');
-  if (err) {
-    console.log(err);
-    console.log(err.stack);
-  }
-  res.status(err.status ? err.status : 400).send(typeof err === 'string' ? {message: err} : err);
-});
-
 // An object to store handler events.
 let handlers = {};
 


### PR DESCRIPTION
Adds an ability for users to use __or operator in query strings making resource to look for one of the listing conditions match. 
Works in both cases when suboperators of OR operator are already parsed in req.query or not. This is needed because if some cases server using resourcejs preproccesses query strings to coerce types fort example. 