### PR TITLE
await options.hooks.post.after call

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -842,7 +842,7 @@ class Resource {
             const item = await model.save(writeOptions)
             debug.post(item);
             // Trigger any after hooks before responding.
-            return options.hooks.post.after.call(
+            return await options.hooks.post.after.call(
               this,
               req,
               res,


### PR DESCRIPTION
Because we are not awaiting options.hooks.post.after the catch will never be called because the hook function does not await for the function call to finish