### PR TITLE
fix: count query pipeline after clone

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -607,12 +607,13 @@ class Resource {
       // Get the query object.
       let countQuery = req.countQuery || req.modelQuery || req.model || this.model;
       const query = req.modelQuery || req.model || this.model;
+      const pipeline = countQuery.pipeline;
 
       // Make sure to clone the count query if it is available.
       if (typeof countQuery.clone === 'function') {
         countQuery = countQuery.clone();
         // countQuery pipeline gets removed by clone() so add it back
-        countQuery.pipeline = req.countQuery.pipeline;
+        countQuery.pipeline = pipeline;
       }
 
       // Get the find query.


### PR DESCRIPTION
The PR contain fix related to failed test ('A GET (Index) request to a child resource should invoke the global handlers’).
Test failed when req.countQuery was not set and we tried to get pipeline from undefined.  To fix the problem I save pipeline from countQuery before cloning and restore it after.