### PR TITLE
Added sanitization to query params

### DIFF
--- a/Resource.js
+++ b/Resource.js
@@ -623,7 +623,8 @@ class Resource {
 
       // Sanitize Queries that have [$operations]
       req.query = utils.sanitizeQueryParameters(req.query);
-
+      // Get the find query.
+      const findQuery = this.getFindQuery(req, null, query._conditions);
       // Get the query object.
       let countQuery = req.countQuery || req.modelQuery || req.model || this.model;
       const query = req.modelQuery || req.model || this.model;
@@ -637,9 +638,6 @@ class Resource {
       }
 
       try {
-        // Get the find query.
-        const findQuery = this.getFindQuery(req, null, query._conditions);
-
         // First get the total count.
         const count = await this.countQuery( countQuery.find(findQuery), countQuery.pipeline || query.pipeline).countDocuments();
         // Get the default limit.

--- a/Resource.js
+++ b/Resource.js
@@ -439,8 +439,10 @@ class Resource {
     const findQuery = {};
     options = options || this.options;
 
+    const sanitizeQuery = utils.sanitizeQueryParameters(req.query);
+
     // Get the filters and omit the limit, skip, select, sort and populate.
-    const {limit, skip, select, sort, populate, ...filters} = req.query;
+    const {limit, skip, select, sort, populate, ...filters} = sanitizeQuery;
 
     // Sets the findQuery property.
     const setFindQuery = function(name, value) {
@@ -633,11 +635,11 @@ class Resource {
         countQuery.pipeline = pipeline;
       }
 
-      // Get the find query.
-      const findQuery = this.getFindQuery(req, null, query._conditions);
-
-      // First get the total count.
       try {
+        // Get the find query.
+        const findQuery = this.getFindQuery(req, null, query._conditions);
+
+        // First get the total count.
         const count = await this.countQuery( countQuery.find(findQuery), countQuery.pipeline || query.pipeline).countDocuments();
         // Get the default limit.
         const defaults = { limit: 10, skip: 0 };

--- a/Resource.js
+++ b/Resource.js
@@ -439,10 +439,8 @@ class Resource {
     const findQuery = {};
     options = options || this.options;
 
-    const sanitizeQuery = utils.sanitizeQueryParameters(req.query);
-
     // Get the filters and omit the limit, skip, select, sort and populate.
-    const {limit, skip, select, sort, populate, ...filters} = sanitizeQuery;
+    const {limit, skip, select, sort, populate, ...filters} = req.query;
 
     // Sets the findQuery property.
     const setFindQuery = function(name, value) {
@@ -622,6 +620,9 @@ class Resource {
         debug.index('Skipping Resource');
         return next();
       }
+
+      // Sanitize Queries that have [$operations]
+      req.query = utils.sanitizeQueryParameters(req.query);
 
       // Get the query object.
       let countQuery = req.countQuery || req.modelQuery || req.model || this.model;

--- a/utils.js
+++ b/utils.js
@@ -26,4 +26,39 @@ const isEmpty = (obj) => {
   return !obj || (Object.entries(obj).length === 0 && obj.constructor === Object);
 };
 
-module.exports = { zipObject, isObjectLike, isEmpty, get, set };
+/**
+ * Recursively removes properties whose keys start with '$' from an object or array.
+ * @param {any} params - The object or array to clean.
+ * @returns {any} A new object/array with '$' properties removed, or the original primitive value.
+ */
+const sanitizeQueryParameters = (params) => {
+  // If the data is not an object or is null, return it as is.
+  if (params === null || typeof params !== 'object') {
+    return params;
+  }
+
+  // If it's an array, process each element.
+  if (Array.isArray(params)) {
+    return params.map(item => sanitizeQueryParameters(item));
+  }
+
+  // If it's a plain object, iterate over its keys.
+  const cleanedObject = {};
+  for (const key in params) {
+    // Ensure the key is directly on the object and not inherited
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      // If the key does NOT start with '$', include it and recursively clean its value.
+      if (!key.startsWith('$')) {
+        cleanedObject[key] = sanitizeQueryParameters(params[key]);
+      }
+      else {
+        throw new Error(`[${key}] is not allowed. Please use __${key} instead. Read https://github.com/travist/resourcejs#filtering-the-results for a list of available query arguments`);
+      }
+      // If the key starts with '$', it's skipped.
+    }
+  }
+
+  return cleanedObject;
+};
+
+module.exports = { zipObject, isObjectLike, isEmpty, get, set, sanitizeQueryParameters };

--- a/utils.js
+++ b/utils.js
@@ -53,19 +53,12 @@ const sanitizeQueryParameters = (params) => {
         continue;
       }
 
-      // 4. Get the full property descriptor for the current key.
       const descriptor = Object.getOwnPropertyDescriptor(params, key);
 
-      // 5. If it's a data property (has a 'value'), recursively sanitize its value.
       if ('value' in descriptor) {
         descriptor.value = sanitizeQueryParameters(descriptor.value);
       }
-      // If it's an accessor property (getter/setter), the getter/setter functions
-      // themselves are copied as they are, preserving the object's behavior.
-      // Sanitizing the *result* of a getter would require calling it, which can
-      // alter semantics and is a more complex use case.
 
-      // 6. Define the property on the new cleaned object using its (potentially updated) descriptor.
       Object.defineProperty(cleanedObject, key, descriptor);
     }
   }

--- a/utils.js
+++ b/utils.js
@@ -28,32 +28,45 @@ const isEmpty = (obj) => {
 
 /**
  * Recursively removes properties whose keys start with '$' from an object or array.
+ * This version preserves the original object's prototype chain and property descriptors
+ * (including getters and setters) for generic objects.
+ *
+ * It returns a new, sanitized object or array without modifying the original.
+ *
  * @param {any} params - The object or array to clean.
- * @returns {any} A new object/array with '$' properties removed, or the original primitive value.
+ * @returns {any} A new object/array with '$' properties removed, or the original primitive value/uncleanable object type.
  */
 const sanitizeQueryParameters = (params) => {
-  // If the data is not an object or is null, return it as is.
   if (params === null || typeof params !== 'object') {
     return params;
   }
 
-  // If it's an array, process each element.
   if (Array.isArray(params)) {
     return params.map(item => sanitizeQueryParameters(item));
   }
 
-  // If it's a plain object, iterate over its keys.
-  const cleanedObject = {};
+  const cleanedObject = Object.create(Object.getPrototypeOf(params));
+
   for (const key in params) {
-    // Ensure the key is directly on the object and not inherited
-    if (Object.prototype.hasOwnProperty.call(params, key)) {
-      // If the key does NOT start with '$', include it and recursively clean its value.
-      if (!key.startsWith('$')) {
-        cleanedObject[key] = sanitizeQueryParameters(params[key]);
+    if (Object.hasOwn(params, key)) {
+      if (key.startsWith('$')) {
+        continue;
       }
-      else {
-        throw new Error(`[${key}] is not allowed. Please use __${key} instead. Read https://github.com/travist/resourcejs#filtering-the-results for a list of available query arguments`);
+
+      // 4. Get the full property descriptor for the current key.
+      const descriptor = Object.getOwnPropertyDescriptor(params, key);
+
+      // 5. If it's a data property (has a 'value'), recursively sanitize its value.
+      if ('value' in descriptor) {
+        descriptor.value = sanitizeQueryParameters(descriptor.value);
       }
+      // If it's an accessor property (getter/setter), the getter/setter functions
+      // themselves are copied as they are, preserving the object's behavior.
+      // Sanitizing the *result* of a getter would require calling it, which can
+      // alter semantics and is a more complex use case.
+
+      // 6. Define the property on the new cleaned object using its (potentially updated) descriptor.
+      Object.defineProperty(cleanedObject, key, descriptor);
     }
   }
 

--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,6 @@ const sanitizeQueryParameters = (params) => {
       else {
         throw new Error(`[${key}] is not allowed. Please use __${key} instead. Read https://github.com/travist/resourcejs#filtering-the-results for a list of available query arguments`);
       }
-      // If the key starts with '$', it's skipped.
     }
   }
 


### PR DESCRIPTION
Express 4.x allows object creation on the req.query via this box syntax []. For example a query of hello?my[data][$regex]="^test" would produce a req.query of
``` 
{
    my: {
        data: {
            '$regex': '^test'
        }
    }
}
```
This PR sanitizes any $properties in the JSON of req.query
It should also be noted that this only vulnerable when app.set('query parser', 'extended'); is used. This is the default in express 4.x and below but not an issue if express version is 5.x and above. Anyone who has app.set('query parser', 'simple') is not effected by this